### PR TITLE
2019-06-10 GUARD-43 Magento 2.2.8 support

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -25,6 +25,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-// 2.4.8.0 - magento 2 supported, 8 build, 4 subversion (includes significant features and codechanges)
+// 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.8.1.0" ) ]
+[ assembly : AssemblyVersion( "2.9.0.0" ) ]

--- a/src/MagentoAccess/MagentoAccess.csproj
+++ b/src/MagentoAccess/MagentoAccess.csproj
@@ -86,6 +86,7 @@
     </Compile>
     <Compile Include="Misc\Cache.cs" />
     <Compile Include="Misc\ICreateCallInfoExtensions.cs" />
+    <Compile Include="Misc\MagentoStoreVersion.cs" />
     <Compile Include="Misc\PagingModel.cs" />
     <Compile Include="Misc\RpcInvoker.cs" />
     <Compile Include="Models\CreateOrders\CreateOrderModel.cs" />

--- a/src/MagentoAccess/MagentoService.cs
+++ b/src/MagentoAccess/MagentoService.cs
@@ -276,8 +276,10 @@ namespace MagentoAccess
 				var magentoLowLevelServices = this.MagentoServiceLowLevelSoapFactory.GetAll();
 				var storeVersionFromApi = await this.GetMagentoStoreVersionAsync( mark ).ConfigureAwait( false );
 
-				// use Magento Rest API for version higher than 2.1+
-				if ( storeVersionFromApi != null && storeVersionFromApi.Version.Major == 2 && storeVersionFromApi.Version.Minor > 1 )
+				// use Magento Rest API for version higher than 2.1+ or when version is not set (prerelease)
+				if ( storeVersionFromApi != null 
+					&& ( storeVersionFromApi.Version.Major == 2 && storeVersionFromApi.Version.Minor > 1
+						|| storeVersionFromApi.Version == new Version( 1, 0 ) ) )
 				{
 					var restService = magentoLowLevelServices.FirstOrDefault( s => s.Key.Equals( MagentoVersions.MR_2_0_0_0 ) );
 						

--- a/src/MagentoAccess/Misc/Extensions.cs
+++ b/src/MagentoAccess/Misc/Extensions.cs
@@ -273,28 +273,26 @@ namespace MagentoAccess.Misc
 
 		public static MagentoStoreVersion ParseMagentoStoreInfoString( this string storeVersionRaw )
 		{
-			MagentoStoreVersion magentoStoreVersion = null;
+			if ( string.IsNullOrEmpty( storeVersionRaw ) )
+				return null;
 
-			if ( !string.IsNullOrEmpty( storeVersionRaw ) )
+			// format example: Magento/2.2 (Community)
+			var regExp = new Regex( @"Magento/([1-9]{1}\.[0-9]{1,2}(\.[0-9]{1,2})?)\s+\(([a-zA-Z]+)\)" );
+			var match = regExp.Match( storeVersionRaw );
+
+			if ( match.Success )
 			{
-				// format example: Magento/2.2 (Community)
-				var regExp = new Regex( @"Magento/([1-9]{1}\.[0-9]{1,2}(\.[0-9]{1,2})?)\s+\(([a-zA-Z]+)\)" );
-				var match = regExp.Match( storeVersionRaw );
+				var storeVersion = match.Groups[1].Value;
+				var storeEdition = match.Groups[3].Value;
 
-				if ( match.Success )
+				return new MagentoStoreVersion()
 				{
-					var storeVersion = match.Groups[1].Value;
-					var storeEdition = match.Groups[3].Value;
-
-					magentoStoreVersion = new MagentoStoreVersion()
-					{
-						Version = new Version( storeVersion ), 
-						MagentoEdition = storeEdition.Contains( "CE" ) || storeEdition.Contains( MagentoEdition.Community ) ? MagentoEdition.Community : MagentoEdition.Enterprise
-					};
-				}
+					Version = new Version( storeVersion ), 
+					MagentoEdition = storeEdition.Contains( MagentoEdition.CommunityAbbr ) || storeEdition.Contains( MagentoEdition.Community ) ? MagentoEdition.Community : MagentoEdition.Enterprise
+				};
 			}
 
-			return magentoStoreVersion;
+			return null;
 		}
 	}
 

--- a/src/MagentoAccess/Misc/Extensions.cs
+++ b/src/MagentoAccess/Misc/Extensions.cs
@@ -276,6 +276,10 @@ namespace MagentoAccess.Misc
 			if ( string.IsNullOrEmpty( storeVersionRaw ) )
 				return null;
 
+			// version not specified (prerelease version)
+			if ( storeVersionRaw.ToLower().Contains("no version set") )
+				return new MagentoStoreVersion() { Version = new Version( 1, 0 ), MagentoEdition = MagentoEdition.Community };
+
 			// format example: Magento/2.2 (Community)
 			var regExp = new Regex( @"Magento/([1-9]{1}\.[0-9]{1,2}(\.[0-9]{1,2})?)\s+\(([a-zA-Z]+)\)" );
 			var match = regExp.Match( storeVersionRaw );

--- a/src/MagentoAccess/Misc/Extensions.cs
+++ b/src/MagentoAccess/Misc/Extensions.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 using MagentoAccess.Models.GetOrders;
@@ -268,6 +269,32 @@ namespace MagentoAccess.Misc
 			{
 				yield return source.Current;
 			}
+		}
+
+		public static MagentoStoreVersion ParseMagentoStoreInfoString( this string storeVersionRaw )
+		{
+			MagentoStoreVersion magentoStoreVersion = null;
+
+			if ( !string.IsNullOrEmpty( storeVersionRaw ) )
+			{
+				// format example: Magento/2.2 (Community)
+				var regExp = new Regex( @"Magento/([1-9]{1}\.[0-9]{1,2}(\.[0-9]{1,2})?)\s+\(([a-zA-Z]+)\)" );
+				var match = regExp.Match( storeVersionRaw );
+
+				if ( match.Success )
+				{
+					var storeVersion = match.Groups[1].Value;
+					var storeEdition = match.Groups[3].Value;
+
+					magentoStoreVersion = new MagentoStoreVersion()
+					{
+						Version = new Version( storeVersion ), 
+						MagentoEdition = storeEdition.Contains( "CE" ) || storeEdition.Contains( MagentoEdition.Community ) ? MagentoEdition.Community : MagentoEdition.Enterprise
+					};
+				}
+			}
+
+			return magentoStoreVersion;
 		}
 	}
 

--- a/src/MagentoAccess/Misc/MagentoStoreVersion.cs
+++ b/src/MagentoAccess/Misc/MagentoStoreVersion.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/MagentoAccess/Misc/MagentoStoreVersion.cs
+++ b/src/MagentoAccess/Misc/MagentoStoreVersion.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MagentoAccess.Misc
+{
+	public class MagentoStoreVersion
+	{
+		public Version Version { get; set; }
+		public string MagentoEdition { get; set; }
+	}
+}

--- a/src/MagentoAccess/Misc/MagentoVersions.cs
+++ b/src/MagentoAccess/Misc/MagentoVersions.cs
@@ -19,6 +19,8 @@
 	public static class MagentoEdition
 	{
 		public const string Community = "Community";
+		public const string CommunityAbbr = "CE";
 		public const string Enterprise = "Enterprise";
+		public const string EnterpriseAbbr = "EE";
 	}
 }

--- a/src/MagentoAccessTests/Misc/ExtensionsTest.cs
+++ b/src/MagentoAccessTests/Misc/ExtensionsTest.cs
@@ -28,6 +28,50 @@ namespace MagentoAccessTests.Misc
 		}
 
 		[ Test ]
+		public void ParseMagentoStoreCommunityVersion()
+		{
+			var storeVersionRaw = "Magento/2.2 (Community)";
+
+			var storeVersion = storeVersionRaw.ParseMagentoStoreInfoString();
+
+			Assert.IsTrue( storeVersion.Version.Equals( new System.Version( 2, 2 ) ) );
+			Assert.IsTrue( storeVersion.MagentoEdition.Equals( MagentoEdition.Community ));
+		}
+
+		[ Test ]
+		public void ParseMagentoStoreCommunityVersionWithAbbr()
+		{
+			var storeVersionRaw = "Magento/2.2 (CE)";
+
+			var storeVersion = storeVersionRaw.ParseMagentoStoreInfoString();
+
+			Assert.IsTrue( storeVersion.Version.Equals( new System.Version( 2, 2 ) ) );
+			Assert.IsTrue( storeVersion.MagentoEdition.Equals( MagentoEdition.Community ));
+		}
+
+		[ Test ]
+		public void ParseMagentoStoreEnterpiseVersion()
+		{
+			var storeVersionRaw = "Magento/2.2 (Enterpise)";
+
+			var storeVersion = storeVersionRaw.ParseMagentoStoreInfoString();
+
+			Assert.IsTrue( storeVersion.Version.Equals( new System.Version( 2, 2 ) ) );
+			Assert.IsTrue( storeVersion.MagentoEdition.Equals( MagentoEdition.Enterprise ));
+		}
+
+		[ Test ]
+		public void ParseMagentoStoreCommunityVersionWithBuildInfo()
+		{
+			var storeVersionRaw = "Magento/2.9.15 (Community)";
+
+			var storeVersion = storeVersionRaw.ParseMagentoStoreInfoString();
+
+			Assert.IsTrue( storeVersion.Version.Equals( new System.Version( 2, 9, 15 ) ) );
+			Assert.IsTrue( storeVersion.MagentoEdition.Equals( MagentoEdition.Community ));
+		}
+
+		[ Test ]
 		[ TestCaseSource( typeof( BatchTestCases ), "Cases" ) ]
 		public void Batch( BatchTestCase batchCase )
 		{

--- a/src/MagentoAccessTests/Misc/ExtensionsTest.cs
+++ b/src/MagentoAccessTests/Misc/ExtensionsTest.cs
@@ -72,6 +72,17 @@ namespace MagentoAccessTests.Misc
 		}
 
 		[ Test ]
+		public void ParseMagentoStoreVersionWhenItsNotSpecified()
+		{
+			var storeVersionRaw = "Magento/No version set (parsed as 1.0 (Community)";
+
+			var storeVersion = storeVersionRaw.ParseMagentoStoreInfoString();
+
+			Assert.IsTrue( storeVersion.Version.Equals( new System.Version( 1, 0 ) ) );
+			Assert.IsTrue( storeVersion.MagentoEdition.Equals( MagentoEdition.Community ));
+		}
+
+		[ Test ]
 		[ TestCaseSource( typeof( BatchTestCases ), "Cases" ) ]
 		public void Batch( BatchTestCase batchCase )
 		{


### PR DESCRIPTION
- now by default we try to detect Magento Store version via API (http://< magento store >/magento_version). This approach works only for Magento 2.0+ versions;
- now we use Rest API by default for new versions (2.2+) because it's more stable than Soap.