### PR TITLE
2019-08-07 GUARD-144 Object reference error

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.9.2.0" ) ]
+[ assembly : AssemblyVersion( "2.9.5.0" ) ]

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel.cs
@@ -132,6 +132,9 @@ namespace MagentoAccess.Services.Rest.v2x
 			{
 				try
 				{
+					if ( this.ProductRepository == null || this.SalesOrderRepository == null )
+						await ReauthorizeAsync().ConfigureAwait( false );
+
 					var task1 = this.ProductRepository.GetProductsAsync( DateTime.UtcNow, mark );
 					var task2 = this.SalesOrderRepository.GetOrdersAsync( DateTime.UtcNow.AddMinutes( -1 ), DateTime.UtcNow, new PagingModel( 10, 1 ), mark );
 					await Task.WhenAll( task1, task2 ).ConfigureAwait( false );

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
@@ -31,6 +31,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				case WebExceptionStatus.ConnectionClosed:
 				case WebExceptionStatus.ConnectFailure:
 				case WebExceptionStatus.Timeout:
+				case WebExceptionStatus.SecureChannelFailure:
 					return true;
 				default:
 					return false;

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/CorrectCredentialsAndUrl.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/CorrectCredentialsAndUrl.cs
@@ -17,6 +17,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.PingSoap
 		{
 			// ------------ Arrange
 			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
+			magentoService.DetermineMagentoVersionAndSetupServiceAsync().GetAwaiter().GetResult();
 
 			// ------------ Act
 			Action act = () =>


### PR DESCRIPTION
*Summary*

I found out the following error in the logs when SV tries to ping Magento server (some kind of working service check):

`2019-08-07 08:02:17.253 +00:00 [Verbose] [magento]	["2.9.4.0"]	[Exception]	[mark:]
MagentoAccess.MagentoCommonException: PingSoapAsync:{MethodName:PingSoapAsync, "Store":"...","LogRawMessages":false,"StoreVersion":"2.3","GetStockItemsWithoutSkuImplementedWithPages":false,"GetOrderByIdForFullInformation":false,"GetOrdersUsesEntityInsteadOfIncrementId":true}, MethodParameters:, Mark:"SyncOrders-67c249ff-fabf-407a-98ae-aa5e4d367192", {TenantId:Tenant-345246, AccountId:MagentoAccount-8495}} ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at MagentoAccess.Services.Rest.v2x.MagentoServiceLowLevel.<>c__DisplayClass66_0.<<GetMagentoInfoAsync>b__0>d.MoveNext() in C:\Users\Farrakhov Bulat\Desktop\Работа\SkuVault\Integrations\magentoAccess\src\MagentoAccess\Services\Rest\v2x\MagentoServiceLowLevel.cs:line 144
--- End of stack trace from previous location where exception was thrown ---`

It seems that somehow ProductRepository or SalesOrderRepository can be null. So I decided to do reauthorizing in this case.

Also I discovered that sometime we can't establish SSL connection with remote server:
`2019-08-07 08:18:23.583 +00:00 [Verbose] [magento]	["2.9.4.0"]	[Exception]	[mark:]
MagentoAccess.MagentoCommonException: PingSoapAsync:{MethodName:PingSoapAsync, "LogRawMessages":false,"StoreVersion":"2.3","GetStockItemsWithoutSkuImplementedWithPages":false,"GetOrderByIdForFullInformation":false,"GetOrdersUsesEntityInsteadOfIncrementId":true}, MethodParameters:, Mark:"SyncOrders-a4460866-4d46-4c9a-bea4-4708af706998", {TenantId:Tenant-345246, AccountId:MagentoAccount-8495}} ---> MagentoAccess.MagentoWebException: Exception occured on GetResponseStreamAsync( webRequest:https://.../index.php/rest/V1/products/?searchCriteria[filterGroups][0][filters][0][field]=updated_at&searchCriteria[filterGroups][0][filters][0][value]=2019-08-07%2008%3A18%3A22&searchCriteria[filterGroups][0][filters][0][conditionType]=gt&searchCriteria[currentPage]=1&searchCriteria[pageSize]=100) ---> System.Net.WebException: The request was aborted: Could not create SSL/TLS secure channel.`

So I specified in ActionPolicies that we should do reattempt in this case also.
