### PR TITLE
2019-09-02 GUARD-199 Value cannot be nul

### DIFF
--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
@@ -98,7 +98,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 					var response = JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
 					
 					if ( response.items != null )
-						response.items = response.items.Where( i => i.sku != null ).ToList();
+						response.items = response.items.Where( i => !string.IsNullOrWhiteSpace( i.sku ) ).ToList();
 
 					return response;
 				}

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
@@ -95,7 +95,12 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			{
 				using( var v = await webRequest.RunAsync( mark ).ConfigureAwait( false ) )
 				{
-					return JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					var response = JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					
+					if ( response.items != null )
+						response.items = response.items.Where( i => i.sku != null ).ToList();
+
+					return response;
 				}
 			} ).ConfigureAwait( false );
 		}


### PR DESCRIPTION
**Summary**
Added check to prevent pulling products from Magento without sku. This caused throwing "Value cannot be null" error when integration tried to get item quantity.