### PR TITLE
2020-07-16 GUARD-519 GUARD-644 Magento-Store-Overloading

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.10.9.0" ) ]
+[ assembly : AssemblyVersion( "2.11.0.0" ) ]

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/CatalogStockItemRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/CatalogStockItemRepository.cs
@@ -58,7 +58,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 
 		public async Task< IEnumerable< bool > > PutStockItemsAsync( IEnumerable< Tuple< string, string, RootObject > > items, Mark mark = null )
 		{
-			var tailProducts = await items.ProcessInBatchAsync( 10, async x => await this.PutStockItemAsync( x.Item1, x.Item2, x.Item3, mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailProducts = await items.ProcessInBatchAsync( 5, async x => await this.PutStockItemAsync( x.Item1, x.Item2, x.Item3, mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			return tailProducts;
 		}
@@ -95,7 +95,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 
 		public async Task< IEnumerable< StockItem > > GetStockItemsAsync( IEnumerable< string > productSku, Mark mark = null )
 		{
-			var tailProducts = await productSku.ProcessInBatchAsync( 10, async x => await this.GetStockItemAsync( x, mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailProducts = await productSku.ProcessInBatchAsync( 5, async x => await this.GetStockItemAsync( x, mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			return tailProducts;
 		}

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
@@ -38,7 +38,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			var pagingModel = new PagingModel( 100, 1 );
 			var products = await this.GetProductsAsync( pagingModel ).ConfigureAwait( false );
 			var pagesToProcess = pagingModel.GetPages( products.totalCount );
-			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 10, async x => await this.GetProductsAsync( new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 5, async x => await this.GetProductsAsync( new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			var resultProducts = new List< RootObject >() { products };
 			resultProducts.AddRange( tailProducts );
@@ -110,7 +110,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			var pagingModel = new PagingModel( 100, 1 );
 			var products = await this.GetProductsAsync( updatedAt, pagingModel, mark.CreateChildOrNull() ).ConfigureAwait( false );
 			var pagesToProcess = pagingModel.GetPages( products.totalCount );
-			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 10, async x => await this.GetProductsAsync( updatedAt, new PagingModel( pagingModel.ItemsPerPage, x ), mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 5, async x => await this.GetProductsAsync( updatedAt, new PagingModel( pagingModel.ItemsPerPage, x ), mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			var resultProducts = new List< RootObject >() { products };
 			resultProducts.AddRange( tailProducts );
@@ -122,7 +122,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			var pagingModel = new PagingModel( 100, 1 );
 			var products = await this.GetProductsAsync( DateTime.MinValue, type, excludeType, pagingModel ).ConfigureAwait( false );
 			var pagesToProcess = pagingModel.GetPages( products.totalCount );
-			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 10, async x => await this.GetProductsAsync( DateTime.MinValue, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 5, async x => await this.GetProductsAsync( DateTime.MinValue, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			var resultProducts = new List< RootObject >() { products };
 			resultProducts.AddRange( tailProducts );
@@ -134,7 +134,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			var pagingModel = new PagingModel( 100, 1 );
 			var products = await this.GetProductsAsync( updatedAt, type, pagingModel ).ConfigureAwait( false );
 			var pagesToProcess = pagingModel.GetPages( products.totalCount );
-			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 10, async x => await this.GetProductsAsync( updatedAt, type, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 5, async x => await this.GetProductsAsync( updatedAt, type, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			var resultProducts = new List< RootObject >() { products };
 			resultProducts.AddRange( tailProducts );
@@ -149,7 +149,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			var pagingModel = new PagingModel( 100, 1 );
 			var products = await this.GetProductsAsync( updatedAt, type, excludeType, pagingModel, mark.CreateChildOrNull() ).ConfigureAwait( false );
 			var pagesToProcess = pagingModel.GetPages( products.totalCount );
-			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 10, async x => await this.GetProductsAsync( updatedAt, type, excludeType, new PagingModel( pagingModel.ItemsPerPage, x ), mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailProducts = await pagesToProcess.ProcessInBatchAsync( 5, async x => await this.GetProductsAsync( updatedAt, type, excludeType, new PagingModel( pagingModel.ItemsPerPage, x ), mark.CreateChildOrNull() ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			var resultProducts = new List< RootObject >() { products };
 			resultProducts.AddRange( tailProducts );

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/SalesOrderRepositoryV1.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/SalesOrderRepositoryV1.cs
@@ -117,7 +117,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				var pagingModel = new PagingModel( 10, 1 );
 				var itemsFirstPage = await this.GetOrdersAsync( ch, pagingModel ).ConfigureAwait( false );
 				var pagesToProcess = pagingModel.GetPages( itemsFirstPage.total_count );
-				var tailItems = await pagesToProcess.ProcessInBatchAsync( 10, async x => await this.GetOrdersAsync( ch, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
+				var tailItems = await pagesToProcess.ProcessInBatchAsync( 5, async x => await this.GetOrdersAsync( ch, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 				var resultItemsInChunk = new List< RootObject >() { itemsFirstPage };
 				resultItemsInChunk.AddRange( tailItems );
@@ -132,7 +132,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			var pagingModel = new PagingModel( 100, 1 );
 			var itemsFirstPage = await this.GetOrdersAsync( updatedFrom, updatedTo, pagingModel ).ConfigureAwait( false );
 			var pagesToProcess = pagingModel.GetPages( itemsFirstPage.total_count );
-			var tailItems = await pagesToProcess.ProcessInBatchAsync( 10, async x => await this.GetOrdersAsync( updatedFrom, updatedTo, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var tailItems = await pagesToProcess.ProcessInBatchAsync( 5, async x => await this.GetOrdersAsync( updatedFrom, updatedTo, new PagingModel( pagingModel.ItemsPerPage, x ) ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			var resultItems = new List< RootObject >() { itemsFirstPage };
 			resultItems.AddRange( tailItems );


### PR DESCRIPTION
**Summary**

It seems that typical Magento store installation cannot handle normally more than 15 000 requests per 30 minutes. In both cases 400 error is being started to throw by Magento server. Although the same request is handled without any errors using tool such as PostMan.

As solution I've decreased threads amount that are used to pull products, product's inventory, orders or update them through REST API. 
5 parallel requests is our standard value in the integrations libraries.