### PR TITLE
GUARD-788 Inventory Sync REST Slow

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.14.0.0" ) ]
+[ assembly : AssemblyVersion( "2.14.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.14.1.0" ) ]
+[ assembly : AssemblyVersion( "2.14.2.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.10.9.0" ) ]
+[ assembly : AssemblyVersion( "2.14.0.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.14.2.0" ) ]
+[ assembly : AssemblyVersion( "2.14.3.0" ) ]

--- a/src/MagentoAccess/MagentoService.cs
+++ b/src/MagentoAccess/MagentoService.cs
@@ -754,7 +754,7 @@ namespace MagentoAccess
 			return resultProducts;
 		}
 
-		private async static Task< IEnumerable< SoapProduct > > GetProductsBySkusViaRestAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, IEnumerable< string > skus, Mark mark )
+		private static async Task< IEnumerable< SoapProduct > > GetProductsBySkusViaRestAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, IEnumerable< string > skus, Mark mark )
 		{
 			var products = await magentoServiceLowLevelSoap.GetProductsBySkusAsync( skus, mark ).ConfigureAwait( false );
 			if( products?.Products == null || !products.Products.Any() )

--- a/src/MagentoAccess/MagentoService.cs
+++ b/src/MagentoAccess/MagentoService.cs
@@ -756,10 +756,11 @@ namespace MagentoAccess
 
 		private async static Task< IEnumerable< SoapProduct > > GetProductsBySkusViaRestAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, IEnumerable< string > skus, Mark mark )
 		{
-			var products = await skus.ProcessInBatchAsync( 5, async sku =>
-				await magentoServiceLowLevelSoap.GetProductBySkuAsync( sku, mark ).ConfigureAwait( false )
-			);
-			return products.ToList();
+			var products = await magentoServiceLowLevelSoap.GetProductsBySkusAsync( skus, mark ).ConfigureAwait( false );
+			if( products?.Products == null || !products.Products.Any() )
+				return new List< SoapProduct >();
+
+			return products.Products;
 		}
 
 		private async Task< string > UpdateStockItemsBySoapByThePiece( IList< Inventory > inventories, Mark mark )

--- a/src/MagentoAccess/MagentoService.cs
+++ b/src/MagentoAccess/MagentoService.cs
@@ -289,7 +289,7 @@ namespace MagentoAccess
 					{
 						if ( await restService.Value.InitAsync( true ).ConfigureAwait( false ) )
 						{
-							return new PingSoapInfo[] { new PingSoapInfo( storeVersionFromApi.Version.ToString(), storeVersionFromApi.MagentoEdition, true, MagentoVersions.MR_2_0_0_0 ) };
+							return new [] { new PingSoapInfo( storeVersionFromApi.Version.ToString(), storeVersionFromApi.MagentoEdition, true, MagentoVersions.MR_2_0_0_0 ) };
 						}
 					}
 				}
@@ -531,7 +531,7 @@ namespace MagentoAccess
 
 				var pingres = await this.PingSoapAsync( markLocal ).ConfigureAwait( false );
 				var magentoServiceLowLevel = this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.ServiceUsedVersion, true, false );
-				var resultProducts = await this.GetProductsBySoap( magentoServiceLowLevel, includeDetails, productType, excludeProductByType, scopes ?? new[] { 0, 1 }, updatedFrom, skus, stockItemsOnly, markLocal ).ConfigureAwait( false );
+				var resultProducts = await GetProductsViaSoapAsync( magentoServiceLowLevel, includeDetails, productType, excludeProductByType, scopes ?? new[] { 0, 1 }, updatedFrom, skus, stockItemsOnly, markLocal ).ConfigureAwait( false );
 				var productBriefInfo = $"Count:{resultProducts.Count()},Product:{resultProducts.ToJson()}";
 				MagentoLogger.LogTraceEnded( this.CreateMethodCallInfo( methodResult : productBriefInfo ), markLocal );
 
@@ -683,11 +683,9 @@ namespace MagentoAccess
 			return dates;
 		}
 
-		private async Task< IEnumerable< Product > > GetProductsBySoap( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, bool includeDetails, string productType, bool productTypeShouldBeExcluded, IEnumerable< int > scopes, DateTime? updatedFrom, IEnumerable< string > skus, bool stockItemsOnly, Mark mark = null )
+		private static async Task< IEnumerable< Product > > GetProductsViaSoapAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, bool includeDetails, string productType, bool productTypeShouldBeExcluded, IEnumerable< int > scopes, DateTime? updatedFrom, IEnumerable< string > skus, bool stockItemsOnly, Mark mark = null )
 		{
 			const int stockItemsListMaxChunkSize = 1000;
-			IEnumerable< Product > resultProducts = new List< Product >();
-
 			SoapGetProductsResponse catalogProductListResponse;
 			if( skus != null && skus.Any() )
 			{
@@ -698,9 +696,10 @@ namespace MagentoAccess
 				}
 				else
 				{
-					catalogProductListResponse = await magentoServiceLowLevelSoap.GetProductsAsync( productType, productTypeShouldBeExcluded, updatedFrom, mark ).ConfigureAwait( false );
-					var soapProducts = ( from p in catalogProductListResponse.Products join s in skus on p.Sku equals s select p ).ToList();
-					catalogProductListResponse.Products = soapProducts;
+					catalogProductListResponse = new SoapGetProductsResponse
+					{
+						Products = await GetProductsBySkusViaRestAsync( magentoServiceLowLevelSoap, skus, mark )
+					};
 				}
 			}
 			else
@@ -708,8 +707,8 @@ namespace MagentoAccess
 				catalogProductListResponse = await magentoServiceLowLevelSoap.GetProductsAsync( productType, productTypeShouldBeExcluded, updatedFrom, mark ).ConfigureAwait( false );
 			}
 
-			if( catalogProductListResponse?.Products == null )
-				return resultProducts;
+			if( catalogProductListResponse?.Products == null || !catalogProductListResponse.Products.Any() )
+				return new List< Product >();
 
 			var products = catalogProductListResponse.Products.ToList();
 			List< InventoryStockItem > stockItems;
@@ -739,6 +738,7 @@ namespace MagentoAccess
 				stockItems = getStockItemsAsync.ToList();
 			}
 
+			IEnumerable< Product > resultProducts;
 			if( stockItemsOnly )
 				resultProducts = ( from stockItemEntity in stockItems join productEntity in products on stockItemEntity.ProductId equals productEntity.ProductId select new Product( stockItemEntity.ProductId, productEntity.ProductId, productEntity.Name, productEntity.Sku, stockItemEntity.Qty, 0, null, productEntity.Type, productEntity.UpdatedAt, stockItemEntity.IsInStock == "True" ) );
 			else
@@ -752,6 +752,14 @@ namespace MagentoAccess
 					resultProducts = ( await fillService.FillProductDetails( resultProducts.Select( x => new ProductDetails( x ) ) ).ConfigureAwait( false ) ).Where( x => x != null ).Select( y => y.ToProduct() );
 			}
 			return resultProducts;
+		}
+
+		private async static Task< IEnumerable< SoapProduct > > GetProductsBySkusViaRestAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, IEnumerable< string > skus, Mark mark )
+		{
+			var products = await skus.ProcessInBatchAsync( 5, async sku =>
+				await magentoServiceLowLevelSoap.GetProductBySkuAsync( sku, mark ).ConfigureAwait( false )
+			);
+			return products.ToList();
 		}
 
 		private async Task< string > UpdateStockItemsBySoapByThePiece( IList< Inventory > inventories, Mark mark )

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Products.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Products.cs
@@ -27,12 +27,12 @@ namespace MagentoAccess.Services.Rest.v2x
 			} );
 		}
 
-		public async Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		public async Task< SoapGetProductsResponse > GetProductsBySkusAsync( IEnumerable< string > skus, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
-				var item = await this.ProductRepository.GetProductAsync( sku ).ConfigureAwait( false );
-				return item != null ? new SoapProduct( item ) : null;
+				var products = await this.ProductRepository.GetProductsBySkusAsync( skus, mark ).ConfigureAwait( false );
+				return new SoapGetProductsResponse( products.SelectMany( x => x.items ).ToList() );
 			} );
 		}
 

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Products.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Products.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using MagentoAccess.Misc;
 using MagentoAccess.Models.GetProducts;
 using MagentoAccess.Models.Services.Rest.v2x.Products;
 using MagentoAccess.Models.Services.Soap.GetProductAttributeMediaList;
@@ -25,6 +24,15 @@ namespace MagentoAccess.Services.Rest.v2x
 			{
 				var products = await this.ProductRepository.GetProductsAsync( updatedFrom ?? DateTime.MinValue, productType, productTypeShouldBeExcluded, mark ).ConfigureAwait( false );
 				return new SoapGetProductsResponse( products.SelectMany( x => x.items ).ToList() );
+			} );
+		}
+
+		public async Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		{
+			return await this.RepeatOnAuthProblemAsync.Get( async () =>
+			{
+				var item = await this.ProductRepository.GetProductAsync( sku ).ConfigureAwait( false );
+				return item != null ? new SoapProduct( item ) : null;
 			} );
 		}
 

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/IProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/IProductRepository.cs
@@ -17,6 +17,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, Mark mark = null );
 		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, string type );
 		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, string type, bool excludeType, Mark mark = null );
+		Task< IEnumerable< RootObject > > GetProductsBySkusAsync( IEnumerable< string > skus, Mark mark );
 		Task< Item > GetProductAsync( string sku );
 		Task< CategoryNode > GetCategoriesTreeAsync();
 		Task< ProductAttribute > GetManufacturersAsync();

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
@@ -185,7 +185,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 
 		public async Task< IEnumerable< RootObject > > GetProductsBySkusAsync( IEnumerable< string > skus, Mark mark )
 		{
-			if( skus == null )
+			if( skus == null || !skus.Any() )
 				return new List< RootObject >();
 
 			const int productSkusPerBatch = 20;

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Products.cs
@@ -145,5 +145,10 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 				res => new SoapGetProductsResponse( res ),
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
+
+		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Products.cs
@@ -146,7 +146,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
 
-		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
@@ -113,5 +113,10 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 				res => new SoapGetProductsResponse( res ),
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
+
+		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
@@ -114,7 +114,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
 
-		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
@@ -114,7 +114,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
 
-		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
@@ -113,5 +113,10 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 				res => new SoapGetProductsResponse( res ),
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
+
+		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Products.cs
@@ -112,5 +112,10 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 				res => new SoapGetProductsResponse( res ),
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
+
+		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Products.cs
@@ -113,7 +113,7 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
 		}
 
-		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Inventory.cs
+++ b/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Inventory.cs
@@ -348,7 +348,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Inventory.cs
+++ b/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Inventory.cs
@@ -348,6 +348,10 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
+		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		{
+			throw new NotImplementedException();
+		}
 
 		private static void AddFilter( FrameworkSearchCriteriaInterface filters, string value, string key, string valueKey )
 		{

--- a/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Inventory.cs
+++ b/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Inventory.cs
@@ -317,6 +317,11 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
+		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		{
+			throw new NotImplementedException();
+		}
+
 
 		private static void AddFilter( FrameworkSearchCriteriaInterface filters, string value, string key, string valueKey )
 		{

--- a/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Inventory.cs
+++ b/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Inventory.cs
@@ -317,7 +317,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
+++ b/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
@@ -30,7 +30,7 @@ namespace MagentoAccess.Services.Soap
 		Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null );
 		Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds );
 		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null );
-		Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null );
+		Task< SoapGetProductsResponse > GetProductsBySkusAsync( IEnumerable< string > skus, Mark mark = null );
 		Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null );
 		Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark );
 		Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark );

--- a/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
+++ b/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
@@ -30,6 +30,7 @@ namespace MagentoAccess.Services.Soap
 		Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null );
 		Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds );
 		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null );
+		Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null );
 		Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null );
 		Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark );
 		Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark );

--- a/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
+++ b/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
@@ -141,6 +141,11 @@ namespace MagentoAccessTests.Misc
 				return null;
 			}
 
+			public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+			{
+				return null;
+			}
+
 			public Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
 			{
 				return null;

--- a/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
+++ b/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
@@ -141,7 +141,7 @@ namespace MagentoAccessTests.Misc
 				return null;
 			}
 
-			public Task< SoapProduct > GetProductBySkuAsync( string sku, Mark mark = null )
+			public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
 			{
 				return null;
 			}

--- a/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/RepositoryTestCases.cs
+++ b/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/RepositoryTestCases.cs
@@ -21,7 +21,7 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 				if ( cliTestStoreCredentials != null )
 					return cliTestStoreCredentials;
 
-				return TestEnvironment.TestStoresConfigsVault.GetActiveConfigs.Where( line => line.V2 == "1" && line.Rest == "1" ).Select( line =>
+				return GetActiveConfigs.Where( line => line.V2 == "1" && line.Rest == "1" ).Select( line =>
 					new TestCaseData( new RepositoryTestCase { MagentoPass = MagentoPass.Create( line.MagentoPass ), MagentoLogin = MagentoLogin.Create( line.MagentoLogin ), Url = MagentoUrl.Create( line.MagentoUrl ) } ).SetName( line.MagentoVersion ) );
 			}
 		}


### PR DESCRIPTION
Inventory Sync REST (Magento 2.2+): When getting products, pass skus from v1 and then only get the products on the skus list, instead of getting ALL products and stockItems for each [v.2.14.0]