### PR TITLE
2020-11-17 GUARD-811 Server-Unavailable-Errors

### DIFF
--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
@@ -24,6 +24,8 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 					{
 						case HttpStatusCode.NotFound:
 						case HttpStatusCode.BadRequest:
+						case HttpStatusCode.ServiceUnavailable:
+						case HttpStatusCode.BadGateway:
 							return true;
 						default:
 							return false;
@@ -32,6 +34,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				case WebExceptionStatus.ConnectFailure:
 				case WebExceptionStatus.Timeout:
 				case WebExceptionStatus.SecureChannelFailure:
+				case WebExceptionStatus.RequestCanceled:
 					return true;
 				default:
 					return false;


### PR DESCRIPTION
**Summary**
Customer's Magento server randomly throws different HTTP errors for different HTTP endpoints during SV's full inventory sync:

`System.Net.WebException: The request was aborted: The request was canceled.`
`System.Net.WebException: The remote server returned an error: (503) Server Unavailable`
`System.Net.WebException: The remote server returned an error: (502) Bad Gateway.`

After the fix, access library will retry HTTP request if faces these errors.