### PR TITLE
2021-01-14 GUARD-1724 Zoey Orders Sync Error #3

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.15.3.0" ) ]
+[ assembly : AssemblyVersion( "2.15.4.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.14.3.0" ) ]
+[ assembly : AssemblyVersion( "2.15.0.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "MagentoAccess" ) ]
 [ assembly : AssemblyCompany( "SkuVault Inc." ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2020 SkuVault Inc." ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2021 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "Magento webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.15.4.0" ) ]
+[ assembly : AssemblyVersion( "2.17.0.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.15.1.0" ) ]
+[ assembly : AssemblyVersion( "2.15.2.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.17.0.0" ) ]
+[ assembly : AssemblyVersion( "2.18.0.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.18.0.0" ) ]
+[ assembly : AssemblyVersion( "2.18.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.15.0.0" ) ]
+[ assembly : AssemblyVersion( "2.15.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.15.2.0" ) ]
+[ assembly : AssemblyVersion( "2.15.3.0" ) ]

--- a/src/MagentoAccess/IMagentoFactory.cs
+++ b/src/MagentoAccess/IMagentoFactory.cs
@@ -1,9 +1,10 @@
-﻿using MagentoAccess.Models.Credentials;
+﻿using MagentoAccess.Misc;
+using MagentoAccess.Models.Credentials;
 
 namespace MagentoAccess
 {
 	public interface IMagentoFactory
 	{
-		IMagentoService CreateService( MagentoAuthenticatedUserCredentials userAuthCredentials, MagentoConfig magentoConfig );
+		IMagentoService CreateService( MagentoAuthenticatedUserCredentials userAuthCredentials, MagentoConfig magentoConfig, MagentoTimeouts operationsTimeouts );
 	}
 }

--- a/src/MagentoAccess/IMagentoService.cs
+++ b/src/MagentoAccess/IMagentoService.cs
@@ -45,5 +45,10 @@ namespace MagentoAccess
 		Task< PingSoapInfo > DetermineMagentoVersionAndSetupServiceAsync( CancellationToken token, Mark mark = null );
 
 		Task< bool > InitAsync( bool supressExc = false );
+
+		/// <summary>
+		///	This property can be used by the client to monitor the last access library's network activity time.
+		/// </summary>
+		DateTime LastActivityTime { get; }
 	}
 }

--- a/src/MagentoAccess/IMagentoService.cs
+++ b/src/MagentoAccess/IMagentoService.cs
@@ -10,6 +10,7 @@ using MagentoAccess.Models.GetMagentoCoreInfo;
 using MagentoAccess.Models.GetOrders;
 using MagentoAccess.Models.GetProducts;
 using MagentoAccess.Models.PutInventory;
+using MagentoAccess.Models.GetShipments;
 using Netco.Logging;
 
 namespace MagentoAccess
@@ -35,6 +36,7 @@ namespace MagentoAccess
 		Task< IEnumerable< Order > > GetOrdersAsync( IEnumerable< string > orderIds, CancellationToken token );
 
 		Task< IEnumerable< Product > > FillProductsDetailsAsync( IEnumerable< Product > products, CancellationToken token, Mark mark = null );
+		Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null );
 
 		Task< IEnumerable< PingSoapInfo > > DetermineMagentoVersionAsync( CancellationToken token, Mark mark = null );
 
@@ -45,6 +47,8 @@ namespace MagentoAccess
 		Task< PingSoapInfo > DetermineMagentoVersionAndSetupServiceAsync( CancellationToken token, Mark mark = null );
 
 		Task< bool > InitAsync( bool supressExc = false );
+
+		bool IsRestAPIUsed { get; set; }
 
 		/// <summary>
 		///	This property can be used by the client to monitor the last access library's network activity time.

--- a/src/MagentoAccess/IMagentoService.cs
+++ b/src/MagentoAccess/IMagentoService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.CreateOrders;
@@ -15,33 +16,33 @@ namespace MagentoAccess
 {
 	public interface IMagentoService
 	{
-		Task< IEnumerable< Order > > GetOrdersAsync( DateTime dateFrom, DateTime dateTo, Mark mark = null );
+		Task< IEnumerable< Order > > GetOrdersAsync( DateTime dateFrom, DateTime dateTo, CancellationToken token, Mark mark = null );
 
-		Task UpdateInventoryAsync( IEnumerable< Inventory > products, Mark mark = null );
+		Task UpdateInventoryAsync( IEnumerable< Inventory > products, CancellationToken token, Mark mark = null );
 
-		Task< IEnumerable< Product > > GetProductsAsync( IEnumerable< int > scopes = null, bool includeDetails = false, string productType = null, bool excludeProductByType = false, DateTime? updatedFrom = null, IEnumerable< string > skus = null, bool stockItemsOnly = true, Mark mark = null );
+		Task< IEnumerable< Product > > GetProductsAsync( CancellationToken token, IEnumerable< int > scopes = null, bool includeDetails = false, string productType = null, bool excludeProductByType = false, DateTime? updatedFrom = null, IEnumerable< string > skus = null, bool stockItemsOnly = true, Mark mark = null );
 
-		Task< PingSoapInfo > PingSoapAsync( Mark mark = null );
+		Task< PingSoapInfo > PingSoapAsync( CancellationToken token, Mark mark = null );
 
-		Task UpdateInventoryBySkuAsync( IEnumerable< InventoryBySku > inventory, IEnumerable< int > scopes = null );
+		Task UpdateInventoryBySkuAsync( IEnumerable< InventoryBySku > inventory, CancellationToken token, IEnumerable< int > scopes = null );
 
-		Task< IEnumerable< CreateProductModelResult > > CreateProductAsync( IEnumerable< CreateProductModel > models );
+		Task< IEnumerable< CreateProductModelResult > > CreateProductAsync( IEnumerable< CreateProductModel > models, CancellationToken token );
 
-		Task< IEnumerable< DeleteProductModelResult > > DeleteProductAsync( IEnumerable< DeleteProductModel > models );
+		Task< IEnumerable< DeleteProductModelResult > > DeleteProductAsync( IEnumerable< DeleteProductModel > models, CancellationToken token );
 
-		Task< IEnumerable< CreateOrderModelResult > > CreateOrderAsync( IEnumerable< CreateOrderModel > models );
+		Task< IEnumerable< CreateOrderModelResult > > CreateOrderAsync( IEnumerable< CreateOrderModel > models, CancellationToken token );
 
-		Task< IEnumerable< Order > > GetOrdersAsync( IEnumerable< string > orderIds );
+		Task< IEnumerable< Order > > GetOrdersAsync( IEnumerable< string > orderIds, CancellationToken token );
 
-		Task< IEnumerable< Product > > FillProductsDetailsAsync( IEnumerable< Product > products, Mark mark = null );
+		Task< IEnumerable< Product > > FillProductsDetailsAsync( IEnumerable< Product > products, CancellationToken token, Mark mark = null );
 
-		Task< IEnumerable< PingSoapInfo > > DetermineMagentoVersionAsync( Mark mark = null );
+		Task< IEnumerable< PingSoapInfo > > DetermineMagentoVersionAsync( CancellationToken token, Mark mark = null );
 
 		MagentoService.SaveAccessToken AfterGettingToken { get; set; }
 
 		Func< string > AdditionalLogInfo { get; set; }
 
-		Task< PingSoapInfo > DetermineMagentoVersionAndSetupServiceAsync( Mark mark = null );
+		Task< PingSoapInfo > DetermineMagentoVersionAndSetupServiceAsync( CancellationToken token, Mark mark = null );
 
 		Task< bool > InitAsync( bool supressExc = false );
 	}

--- a/src/MagentoAccess/MagentoAccess.csproj
+++ b/src/MagentoAccess/MagentoAccess.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Services\Rest\v2x\MagentoServiceLowLevel.cs" />
     <Compile Include="Services\Rest\v2x\MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory.cs" />
     <Compile Include="Services\Rest\v2x\Repository\ActionPolicies.cs" />
+    <Compile Include="Services\Rest\v2x\Repository\BaseRepository.cs" />
     <Compile Include="Services\Rest\v2x\Repository\ISalesOrderRepositoryV1.cs" />
     <Compile Include="Services\Rest\v2x\Repository\IIntegrationAdminTokenRepository.cs" />
     <Compile Include="Services\Rest\v2x\Repository\IntegrationAdminTokenRepository.cs" />

--- a/src/MagentoAccess/MagentoAccess.csproj
+++ b/src/MagentoAccess/MagentoAccess.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Misc\Cache.cs" />
     <Compile Include="Misc\ICreateCallInfoExtensions.cs" />
     <Compile Include="Misc\MagentoStoreVersion.cs" />
+    <Compile Include="Misc\MagentoTimeouts.cs" />
     <Compile Include="Misc\PagingModel.cs" />
     <Compile Include="Misc\RpcInvoker.cs" />
     <Compile Include="Models\CreateOrders\CreateOrderModel.cs" />

--- a/src/MagentoAccess/MagentoAccess.csproj
+++ b/src/MagentoAccess/MagentoAccess.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Models\GetProducts\Category.cs" />
     <Compile Include="Models\GetProducts\MagentoUrl.cs" />
     <Compile Include="Models\GetProducts\Product.cs" />
+    <Compile Include="Models\GetShipments\Shipment.cs" />
     <Compile Include="Models\PutInventory\Inventory.cs" />
     <Compile Include="Models\Services\Rest\v2x\CatalogStockItemRepository\RootObject.cs" />
     <Compile Include="Models\Services\Rest\v2x\Products\CategoryNode.cs" />
@@ -126,6 +127,7 @@
     <Compile Include="Models\Services\Rest\v2x\Products\ProductAttribute.cs" />
     <Compile Include="Models\Services\Rest\v2x\Products\RootObject.cs" />
     <Compile Include="Models\Services\Rest\v2x\SalesOrderRepository\RootObject.cs" />
+    <Compile Include="Models\Services\Rest\v2x\SalesOrderRepository\ShipmentsResponse.cs" />
     <Compile Include="Models\Services\Rest\v2x\SearchCriteria.cs" />
     <Compile Include="Models\Services\Soap\GetCategoryTree\CategoryNode.cs" />
     <Compile Include="Models\Services\Soap\GetCategoryTree\GetCategoryTreeResponse.cs" />

--- a/src/MagentoAccess/MagentoException.cs
+++ b/src/MagentoAccess/MagentoException.cs
@@ -61,16 +61,25 @@ namespace MagentoAccess
 
 	public class MagentoWebException: MagentoException
 	{
-		public MagentoWebException( string message, Exception exception )
+		public HttpStatusCode? StatusCode { get; private set; }
+
+		public MagentoWebException( string message, Exception exception, HttpStatusCode? statusCode )
 			: base( message, exception )
+		{
+			this.StatusCode = statusCode;
+		}
+
+		public MagentoWebException( string message, Exception exception )
+			: this( message, exception, null )
 		{
 		}
 
 		internal bool IsNotFoundException()
 		{
-			var webException = this.InnerException as WebException;
-			var response = webException?.Response as HttpWebResponse;
-			return webException?.Status == WebExceptionStatus.ProtocolError && response?.StatusCode == HttpStatusCode.NotFound;
+			if ( this.StatusCode == HttpStatusCode.NotFound )
+				return true;
+
+			return false;
 		}
 	}
 

--- a/src/MagentoAccess/MagentoFactory.cs
+++ b/src/MagentoAccess/MagentoFactory.cs
@@ -1,14 +1,15 @@
 ﻿using CuttingEdge.Conditions;
+using MagentoAccess.Misc;
 using MagentoAccess.Models.Credentials;
 
 namespace MagentoAccess
 {
 	public class MagentoFactory: IMagentoFactory
 	{
-		public IMagentoService CreateService( MagentoAuthenticatedUserCredentials userAuthCredentials, MagentoConfig magentoConfig )
+		public IMagentoService CreateService( MagentoAuthenticatedUserCredentials userAuthCredentials, MagentoConfig magentoConfig, MagentoTimeouts operationsTimeouts )
 		{
 			Condition.Requires( userAuthCredentials, "userAuthCredentials" ).IsNotNull();
-			return new MagentoService( userAuthCredentials, magentoConfig );
+			return new MagentoService( userAuthCredentials, magentoConfig, operationsTimeouts );
 		}
 	}
 }

--- a/src/MagentoAccess/MagentoService.cs
+++ b/src/MagentoAccess/MagentoService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using AutoMapper.Configuration.Conventions;
@@ -51,7 +52,7 @@ namespace MagentoAccess
 		private MagentoAuthenticatedUserCredentials Credentials { get; set; }
 		public const string UserAgentHeader = "SkuVault MagentoAccessLibrary C#";
 
-		public async Task< IEnumerable< CreateProductModelResult > > CreateProductAsync( IEnumerable< CreateProductModel > models )
+		public async Task< IEnumerable< CreateProductModelResult > > CreateProductAsync( IEnumerable< CreateProductModel > models, CancellationToken token )
 		{
 			var methodParameters = models.ToJson();
 			var mark = Mark.CreateNew();
@@ -60,7 +61,7 @@ namespace MagentoAccess
 			{
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo( methodParameters, mark ) );
 
-				var pingres = await this.PingSoapAsync().ConfigureAwait( false );
+				var pingres = await this.PingSoapAsync( token ).ConfigureAwait( false );
 				//crunch for old versions
 				var magentoServiceLowLevelSoap = this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.StoreVersion, true, false );
 
@@ -69,7 +70,7 @@ namespace MagentoAccess
 					MagentoLogger.LogTrace( $"CreatingProduct: {this.CreateMethodCallInfo( mark : mark, methodParameters : x.ToJson() )}" );
 
 					var res = new CreateProductModelResult( x );
-					res.Result = await magentoServiceLowLevelSoap.CreateProduct( x.StoreId, x.Name, x.Sku, x.IsInStock, x.ProductType ).ConfigureAwait( false );
+					res.Result = await magentoServiceLowLevelSoap.CreateProduct( x.StoreId, x.Name, x.Sku, x.IsInStock, x.ProductType, token ).ConfigureAwait( false );
 
 					MagentoLogger.LogTrace( $"ProductCreated: {this.CreateMethodCallInfo( mark : mark, methodResult : res.ToJson(), methodParameters : x.ToJson() )}" );
 					return res;
@@ -89,7 +90,7 @@ namespace MagentoAccess
 			}
 		}
 
-		public async Task< IEnumerable< CreateOrderModelResult > > CreateOrderAsync( IEnumerable< CreateOrderModel > models )
+		public async Task< IEnumerable< CreateOrderModelResult > > CreateOrderAsync( IEnumerable< CreateOrderModel > models, CancellationToken token )
 		{
 			var methodParameters = models.ToJson();
 			var mark = Mark.CreateNew();
@@ -98,7 +99,7 @@ namespace MagentoAccess
 			{
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo( methodParameters, mark ) );
 
-				var pingres = await this.PingSoapAsync().ConfigureAwait( false );
+				var pingres = await this.PingSoapAsync( token ).ConfigureAwait( false );
 				//crunch for old versions
 				var magentoServiceLowLevelSoap = this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.StoreVersion, true, false );
 
@@ -108,26 +109,26 @@ namespace MagentoAccess
 
 					var res = new CreateOrderModelResult( x );
 
-					var shoppingCartIdTask = magentoServiceLowLevelSoap.CreateCart( x.StoreId );
+					var shoppingCartIdTask = magentoServiceLowLevelSoap.CreateCart( x.StoreId, token );
 					shoppingCartIdTask.Wait();
 					var _shoppingCartId = shoppingCartIdTask.Result;
 
-					var shoppingCartCustomerSetTask = magentoServiceLowLevelSoap.ShoppingCartGuestCustomerSet( _shoppingCartId, x.CustomerFirstName, x.CustomerMail, x.CustomerLastName, x.StoreId );
+					var shoppingCartCustomerSetTask = magentoServiceLowLevelSoap.ShoppingCartGuestCustomerSet( _shoppingCartId, x.CustomerFirstName, x.CustomerMail, x.CustomerLastName, x.StoreId, token );
 					shoppingCartCustomerSetTask.Wait();
 
-					var shoppingCartAddressSet = magentoServiceLowLevelSoap.ShoppingCartAddressSet( _shoppingCartId, x.StoreId );
+					var shoppingCartAddressSet = magentoServiceLowLevelSoap.ShoppingCartAddressSet( _shoppingCartId, x.StoreId, token );
 					shoppingCartAddressSet.Wait();
 
-					var productTask = magentoServiceLowLevelSoap.ShoppingCartAddProduct( _shoppingCartId, x.ProductIds.First(), x.StoreId );
+					var productTask = magentoServiceLowLevelSoap.ShoppingCartAddProduct( _shoppingCartId, x.ProductIds.First(), x.StoreId, token );
 					productTask.Wait();
 
-					var shippingMenthodTask = magentoServiceLowLevelSoap.ShoppingCartSetShippingMethod( _shoppingCartId, x.StoreId );
+					var shippingMenthodTask = magentoServiceLowLevelSoap.ShoppingCartSetShippingMethod( _shoppingCartId, x.StoreId, token );
 					shippingMenthodTask.Wait();
 
-					var paymentMenthodTask = magentoServiceLowLevelSoap.ShoppingCartSetPaymentMethod( _shoppingCartId, x.StoreId );
+					var paymentMenthodTask = magentoServiceLowLevelSoap.ShoppingCartSetPaymentMethod( _shoppingCartId, x.StoreId, token );
 					paymentMenthodTask.Wait();
 
-					var orderIdTask = magentoServiceLowLevelSoap.CreateOrder( _shoppingCartId, x.StoreId );
+					var orderIdTask = magentoServiceLowLevelSoap.CreateOrder( _shoppingCartId, x.StoreId, token );
 					orderIdTask.Wait();
 					res.OrderId = orderIdTask.Result;
 					Task.Delay( 1000 );
@@ -150,7 +151,7 @@ namespace MagentoAccess
 			}
 		}
 
-		public async Task< IEnumerable< DeleteProductModelResult > > DeleteProductAsync( IEnumerable< DeleteProductModel > models )
+		public async Task< IEnumerable< DeleteProductModelResult > > DeleteProductAsync( IEnumerable< DeleteProductModel > models, CancellationToken token )
 		{
 			var methodParameters = models.ToJson();
 			var mark = Mark.CreateNew();
@@ -159,7 +160,7 @@ namespace MagentoAccess
 			{
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo( methodParameters, mark ) );
 
-				var pingres = await this.PingSoapAsync().ConfigureAwait( false );
+				var pingres = await this.PingSoapAsync( token ).ConfigureAwait( false );
 				//crunch for old versions
 				var magentoServiceLowLevelSoap = this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.StoreVersion, true, false );
 
@@ -168,7 +169,7 @@ namespace MagentoAccess
 					MagentoLogger.LogTrace( $"DeleteProduct: {this.CreateMethodCallInfo( mark : mark, methodParameters : x.ToJson() )}" );
 
 					var res = new DeleteProductModelResult( x );
-					res.Result = await magentoServiceLowLevelSoap.DeleteProduct( x.StoreId, x.CategoryId, x.ProductId, x.IdentiferType ).ConfigureAwait( false );
+					res.Result = await magentoServiceLowLevelSoap.DeleteProduct( x.StoreId, x.CategoryId, x.ProductId, x.IdentiferType, token ).ConfigureAwait( false );
 
 					MagentoLogger.LogTrace( $"ProductDeleted: {this.CreateMethodCallInfo( mark : mark, methodResult : res.ToJson(), methodParameters : x.ToJson() )}" );
 					return res;
@@ -189,9 +190,9 @@ namespace MagentoAccess
 		}
 
 		#region constructor
-		public MagentoService( MagentoAuthenticatedUserCredentials magentoAuthenticatedUserCredentials, MagentoConfig magentoConfig )
+		public MagentoService( MagentoAuthenticatedUserCredentials magentoAuthenticatedUserCredentials, MagentoConfig magentoConfig, MagentoTimeouts operationsTimeouts )
 		{
-			ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 			this.Config = magentoConfig;
 			this.Credentials = magentoAuthenticatedUserCredentials;
 
@@ -202,40 +203,40 @@ namespace MagentoAccess
 			switch( cfg.Protocol )
 			{
 				case MagentoDefaultProtocol.RestOnly:
-					lowLevelServicesList.Add( MagentoVersions.MR_2_0_0_0, new MagentoServiceLowLevelSoap_v_r_2_0_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
+					lowLevelServicesList.Add( MagentoVersions.MR_2_0_0_0, new MagentoServiceLowLevelSoap_v_r_2_0_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
 					break;
 				case MagentoDefaultProtocol.SoapOnly:
-					lowLevelServicesList.Add( MagentoVersions.M_2_0_2_0, new MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-					lowLevelServicesList.Add( MagentoVersions.M_2_1_0_0, new MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
+					lowLevelServicesList.Add( MagentoVersions.M_2_0_2_0, new MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+					lowLevelServicesList.Add( MagentoVersions.M_2_1_0_0, new MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
 					break;
 				case MagentoDefaultProtocol.Default:
 				default:
-					lowLevelServicesList.Add( MagentoVersions.MR_2_0_0_0, new MagentoServiceLowLevelSoap_v_r_2_0_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-					lowLevelServicesList.Add( MagentoVersions.M_2_0_2_0, new MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-					lowLevelServicesList.Add( MagentoVersions.M_2_1_0_0, new MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
+					lowLevelServicesList.Add( MagentoVersions.MR_2_0_0_0, new MagentoServiceLowLevelSoap_v_r_2_0_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+					lowLevelServicesList.Add( MagentoVersions.M_2_0_2_0, new MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+					lowLevelServicesList.Add( MagentoVersions.M_2_1_0_0, new MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
 					break;
 			}
 
-			lowLevelServicesList.Add( MagentoVersions.M_1_9_2_0, new MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-			lowLevelServicesList.Add( MagentoVersions.M_1_9_0_1, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-			lowLevelServicesList.Add( MagentoVersions.M_1_8_1_0, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-			lowLevelServicesList.Add( MagentoVersions.M_1_7_0_2, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-			lowLevelServicesList.Add( MagentoVersions.M_1_14_1_0, new MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
-			lowLevelServicesList.Add( MagentoVersions.ZS_1_7_0_1, new ZoeyServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg ) );
+			lowLevelServicesList.Add( MagentoVersions.M_1_9_2_0, new MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+			lowLevelServicesList.Add( MagentoVersions.M_1_9_0_1, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+			lowLevelServicesList.Add( MagentoVersions.M_1_8_1_0, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+			lowLevelServicesList.Add( MagentoVersions.M_1_7_0_2, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+			lowLevelServicesList.Add( MagentoVersions.M_1_14_1_0, new MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
+			lowLevelServicesList.Add( MagentoVersions.ZS_1_7_0_1, new ZoeyServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( magentoAuthenticatedUserCredentials, cfg, operationsTimeouts ) );
 
 			if( cfg.UseVersionByDefaultOnly && !string.IsNullOrWhiteSpace( cfg.VersionByDefault ) )
 			{
 				lowLevelServicesList = lowLevelServicesList.Where( x => string.Equals( x.Key, cfg.VersionByDefault, StringComparison.OrdinalIgnoreCase ) ).ToDictionary( x => x.Key, y => y.Value );
 			}
 
-			this.MagentoServiceLowLevelSoapFactory = new MagentoServiceLowLevelSoapFactory( magentoAuthenticatedUserCredentials, lowLevelServicesList, cfg );
+			this.MagentoServiceLowLevelSoapFactory = new MagentoServiceLowLevelSoapFactory( magentoAuthenticatedUserCredentials, lowLevelServicesList, cfg, operationsTimeouts );
 			var defaultVersion = !string.IsNullOrWhiteSpace( magentoConfig?.VersionByDefault ) ? magentoConfig.VersionByDefault : MagentoVersions.M_1_7_0_2;
 			this.MagentoServiceLowLevelSoap = this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( defaultVersion, true, false );
 		}
 		#endregion
 
 		#region ping
-		public async Task< PingSoapInfo > DetermineMagentoVersionAndSetupServiceAsync( Mark mark = null )
+		public async Task< PingSoapInfo > DetermineMagentoVersionAndSetupServiceAsync( CancellationToken token, Mark mark = null )
 		{
 			mark = mark ?? Mark.CreateNew();
 			try
@@ -243,7 +244,7 @@ namespace MagentoAccess
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo( mark : mark ) );
 
 				var soapInfo = new PingSoapInfo( string.Empty, string.Empty, false, String.Empty );
-				var soapInfos = await this.DetermineMagentoVersionAsync( mark ).ConfigureAwait( false );
+				var soapInfos = await this.DetermineMagentoVersionAsync( token, mark ).ConfigureAwait( false );
 				var pingSoapInfos = soapInfos as IList< PingSoapInfo > ?? soapInfos.ToList();
 				if( pingSoapInfos.Any() )
 				{
@@ -268,7 +269,7 @@ namespace MagentoAccess
 			}
 		}
 
-		public async Task< IEnumerable< PingSoapInfo > > DetermineMagentoVersionAsync( Mark mark = null )
+		public async Task< IEnumerable< PingSoapInfo > > DetermineMagentoVersionAsync( CancellationToken token, Mark mark = null )
 		{
 			mark = mark ?? Mark.CreateNew();
 			try
@@ -298,7 +299,7 @@ namespace MagentoAccess
 				{
 					if( !await kvp.Value.InitAsync( true ).ConfigureAwait( false ) )
 						return null;
-					var getMagentoInfoResponse = await kvp.Value.GetMagentoInfoAsync( true ).ConfigureAwait( false );
+					var getMagentoInfoResponse = await kvp.Value.GetMagentoInfoAsync( true, token ).ConfigureAwait( false );
 					if( getMagentoInfoResponse != null )
 						getMagentoInfoResponse.ServiceVersion = kvp.Key;
 					return getMagentoInfoResponse;
@@ -359,13 +360,13 @@ namespace MagentoAccess
 			return httpClient;
 		}
 
-		public async Task< PingSoapInfo > PingSoapAsync( Mark mark = null )
+		public async Task< PingSoapInfo > PingSoapAsync( CancellationToken token, Mark mark = null )
 		{
 			var markLocal = mark ?? Mark.CreateNew();
 			try
 			{
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo(), markLocal );
-				var magentoInfo = await this.MagentoServiceLowLevelSoap.GetMagentoInfoAsync( false, markLocal ).ConfigureAwait( false );
+				var magentoInfo = await this.MagentoServiceLowLevelSoap.GetMagentoInfoAsync( false, token, markLocal ).ConfigureAwait( false );
 				var soapWorks = !string.IsNullOrWhiteSpace( magentoInfo.MagentoVersion ) || !string.IsNullOrWhiteSpace( magentoInfo.MagentoEdition );
 
 				var magentoCoreInfo = new PingSoapInfo( magentoInfo.MagentoVersion, magentoInfo.MagentoEdition, soapWorks, magentoInfo.ServiceVersion );
@@ -383,7 +384,7 @@ namespace MagentoAccess
 		#endregion
 
 		#region getOrders
-		public async Task< IEnumerable< Order > > GetOrdersAsync( IEnumerable< string > orderIds )
+		public async Task< IEnumerable< Order > > GetOrdersAsync( IEnumerable< string > orderIds, CancellationToken token )
 		{
 			var methodParameters = orderIds.ToJson();
 
@@ -394,7 +395,7 @@ namespace MagentoAccess
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo( methodParameters, mark ) );
 
 				IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap;
-				var pingres = await this.PingSoapAsync().ConfigureAwait( false );
+				var pingres = await this.PingSoapAsync( token ).ConfigureAwait( false );
 				//crunch for old versions
 				magentoServiceLowLevelSoap = string.Equals( pingres.StoreEdition, MagentoVersions.M_1_7_0_2, StringComparison.CurrentCultureIgnoreCase )
 				                             || string.Equals( pingres.StoreEdition, MagentoVersions.M_1_8_1_0, StringComparison.CurrentCultureIgnoreCase )
@@ -404,7 +405,7 @@ namespace MagentoAccess
 				var salesOrderInfoResponses = await orderIds.ProcessInBatchAsync( 16, async x =>
 				{
 					MagentoLogger.LogTrace( $"OrderRequested: {this.CreateMethodCallInfo( mark : mark, methodParameters : x )}" );
-					var res = await magentoServiceLowLevelSoap.GetOrderAsync( x, mark ).ConfigureAwait( false );
+					var res = await magentoServiceLowLevelSoap.GetOrderAsync( x, token, mark ).ConfigureAwait( false );
 					MagentoLogger.LogTrace( $"OrderReceived: {this.CreateMethodCallInfo( mark : mark, methodResult : res.ToJson(), methodParameters : x )}" );
 					return res;
 				} ).ConfigureAwait( false );
@@ -434,7 +435,7 @@ namespace MagentoAccess
 			}
 		}
 
-		public async Task< IEnumerable< Order > > GetOrdersAsync( DateTime dateFrom, DateTime dateTo, Mark mark = null )
+		public async Task< IEnumerable< Order > > GetOrdersAsync( DateTime dateFrom, DateTime dateTo, CancellationToken token, Mark mark = null )
 		{
 			var dateFromUtc = TimeZoneInfo.ConvertTimeToUtc( dateFrom );
 			var dateToUtc = TimeZoneInfo.ConvertTimeToUtc( dateTo );
@@ -451,7 +452,7 @@ namespace MagentoAccess
 
 				var dates = SplitToDates( dateFromUtc, dateToUtc, interval, intervalOverlapping );
 
-				var pingres = await this.PingSoapAsync( Mark.CreateNew( mark ) ).ConfigureAwait( false );
+				var pingres = await this.PingSoapAsync( token, Mark.CreateNew( mark ) ).ConfigureAwait( false );
 				//crunch for old versions
 				var magentoServiceLowLevelSoap = string.Equals( pingres.StoreEdition, MagentoVersions.M_1_7_0_2, StringComparison.CurrentCultureIgnoreCase )
 				                                 || string.Equals( pingres.StoreEdition, MagentoVersions.M_1_8_1_0, StringComparison.CurrentCultureIgnoreCase )
@@ -465,7 +466,7 @@ namespace MagentoAccess
 					var atomicMark = Mark.CreateNew( mark );
 					MagentoLogger.LogTrace( $"OrdersRequested: {this.CreateMethodCallInfo( methodParameters : $"{x.Item1},{x.Item2}" )}", atomicMark );
 
-					var res = await magentoServiceLowLevelSoap.GetOrdersAsync( x.Item1, x.Item2, atomicMark ).ConfigureAwait( false );
+					var res = await magentoServiceLowLevelSoap.GetOrdersAsync( x.Item1, x.Item2, token, atomicMark ).ConfigureAwait( false );
 
 					MagentoLogger.LogTrace( $"OrdersReceived: {this.CreateMethodCallInfo( methodResult : res.ToJson(), methodParameters : $"{x.Item1},{x.Item2}" )}", atomicMark );
 					return res;
@@ -484,7 +485,7 @@ namespace MagentoAccess
 					{
 						var childMark = Mark.CreateNew( mark );
 						MagentoLogger.LogTrace( $"OrderRequested: {this.CreateMethodCallInfo( methodParameters : x.ToStringIds() )}", childMark );
-						var res = await magentoServiceLowLevelSoap.GetOrderAsync( x, childMark ).ConfigureAwait( false );
+						var res = await magentoServiceLowLevelSoap.GetOrderAsync( x, token, childMark ).ConfigureAwait( false );
 						MagentoLogger.LogTrace( $"OrderReceived: {this.CreateMethodCallInfo( methodResult : res.ToJson(), methodParameters : x.ToStringIds() )}", childMark );
 						return res;
 					} ).ConfigureAwait( false );
@@ -521,7 +522,7 @@ namespace MagentoAccess
 		#endregion
 
 		#region getProducts
-		public async Task< IEnumerable< Product > > GetProductsAsync( IEnumerable< int > scopes = null, bool includeDetails = false, string productType = null, bool excludeProductByType = false, DateTime? updatedFrom = null, IEnumerable< string > skus = null, bool stockItemsOnly = true, Mark mark = null )
+		public async Task< IEnumerable< Product > > GetProductsAsync( CancellationToken token, IEnumerable< int > scopes = null, bool includeDetails = false, string productType = null, bool excludeProductByType = false, DateTime? updatedFrom = null, IEnumerable< string > skus = null, bool stockItemsOnly = true, Mark mark = null )
 		{
 			var markLocal = mark ?? Mark.CreateNew();
 			var parameters = $"includeDetails:{includeDetails},productType:{productType},excludeProductByType:{excludeProductByType},updatedFrom:{updatedFrom}";
@@ -529,9 +530,9 @@ namespace MagentoAccess
 			{
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo( methodParameters : parameters ), markLocal );
 
-				var pingres = await this.PingSoapAsync( markLocal ).ConfigureAwait( false );
+				var pingres = await this.PingSoapAsync( token, markLocal ).ConfigureAwait( false );
 				var magentoServiceLowLevel = this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.ServiceUsedVersion, true, false );
-				var resultProducts = await GetProductsViaSoapAsync( magentoServiceLowLevel, includeDetails, productType, excludeProductByType, scopes ?? new[] { 0, 1 }, updatedFrom, skus, stockItemsOnly, markLocal ).ConfigureAwait( false );
+				var resultProducts = await GetProductsViaSoapAsync( magentoServiceLowLevel, includeDetails, productType, excludeProductByType, scopes ?? new[] { 0, 1 }, updatedFrom, skus, stockItemsOnly, token, markLocal ).ConfigureAwait( false );
 				var productBriefInfo = $"Count:{resultProducts.Count()},Product:{resultProducts.ToJson()}";
 				MagentoLogger.LogTraceEnded( this.CreateMethodCallInfo( methodResult : productBriefInfo ), markLocal );
 
@@ -545,14 +546,14 @@ namespace MagentoAccess
 			}
 		}
 
-		public async Task< IEnumerable< Product > > FillProductsDetailsAsync( IEnumerable< Product > products, Mark mark )
+		public async Task< IEnumerable< Product > > FillProductsDetailsAsync( IEnumerable< Product > products, CancellationToken token, Mark mark )
 		{
 			var markLocal = mark ?? Mark.CreateNew();
 			try
 			{
 				MagentoLogger.LogTraceStarted( this.CreateMethodCallInfo( mark : markLocal ) );
 
-				var pingres = await this.PingSoapAsync().ConfigureAwait( false );
+				var pingres = await this.PingSoapAsync( token ).ConfigureAwait( false );
 				var magentoServiceLowLevel = this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.StoreVersion, true, false );
 
 				IEnumerable< Product > resultProducts;
@@ -560,7 +561,7 @@ namespace MagentoAccess
 				string productBriefInfo;
 				if( magentoServiceLowLevelFillProducts != null )
 				{
-					resultProducts = ( await magentoServiceLowLevelFillProducts.FillProductDetails( products.Select( x => new ProductDetails( x ) ) ).ConfigureAwait( false ) ).Select( y => y.ToProduct() );
+					resultProducts = ( await magentoServiceLowLevelFillProducts.FillProductDetails( products.Select( x => new ProductDetails( x ) ), token ).ConfigureAwait( false ) ).Select( y => y.ToProduct() );
 					productBriefInfo = $"Count:{resultProducts.Count()},Product:{resultProducts.ToJson()}";
 				}
 				else
@@ -583,7 +584,7 @@ namespace MagentoAccess
 		#endregion
 
 		#region updateInventory
-		public async Task UpdateInventoryAsync( IEnumerable< Inventory > products, Mark mark = null )
+		public async Task UpdateInventoryAsync( IEnumerable< Inventory > products, CancellationToken token, Mark mark = null )
 		{
 			var productsBriefInfo = products.ToJson();
 			var markLocal = mark ?? Mark.CreateNew();
@@ -595,11 +596,11 @@ namespace MagentoAccess
 				var updateBriefInfo = PredefinedValues.NotAvailable;
 				if( inventories.Any() )
 				{
-					var pingres = await this.PingSoapAsync().ConfigureAwait( false );
+					var pingres = await this.PingSoapAsync( token ).ConfigureAwait( false );
 					//crunch for 1702
 					updateBriefInfo = string.Equals( pingres.StoreVersion, MagentoVersions.M_1_7_0_2, StringComparison.CurrentCultureIgnoreCase )
-						? await this.UpdateStockItemsBySoapByThePiece( inventories, markLocal ).ConfigureAwait( false )
-						: await this.UpdateStockItemsBySoap( inventories, this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.StoreVersion, true, false ), markLocal ).ConfigureAwait( false );
+						? await this.UpdateStockItemsBySoapByThePiece( inventories, token, markLocal ).ConfigureAwait( false )
+						: await this.UpdateStockItemsBySoap( inventories, this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.StoreVersion, true, false ), token, markLocal ).ConfigureAwait( false );
 				}
 
 				MagentoLogger.LogTraceEnded( this.CreateMethodCallInfo( mark : markLocal, methodParameters : productsBriefInfo, methodResult : updateBriefInfo ) );
@@ -612,7 +613,7 @@ namespace MagentoAccess
 			}
 		}
 
-		public async Task UpdateInventoryBySkuAsync( IEnumerable< InventoryBySku > inventory, IEnumerable< int > scopes = null )
+		public async Task UpdateInventoryBySkuAsync( IEnumerable< InventoryBySku > inventory, CancellationToken token, IEnumerable< int > scopes = null )
 		{
 			var mark = Mark.CreateNew();
 			var productsBriefInfo = inventory.ToJson();
@@ -626,21 +627,21 @@ namespace MagentoAccess
 				{
 					if( this.UseSoapOnly )
 					{
-						var pingres = await this.PingSoapAsync().ConfigureAwait( false );
+						var pingres = await this.PingSoapAsync( token ).ConfigureAwait( false );
 						var magentoServiceLowLevelSoap = string.Equals( pingres.StoreEdition, MagentoVersions.M_1_7_0_2, StringComparison.CurrentCultureIgnoreCase )
 						                                 || string.Equals( pingres.StoreEdition, MagentoVersions.M_1_8_1_0, StringComparison.CurrentCultureIgnoreCase )
 						                                 || string.Equals( pingres.StoreEdition, MagentoVersions.M_1_9_0_1, StringComparison.CurrentCultureIgnoreCase )
 						                                 || string.Equals( pingres.StoreEdition, MagentoVersions.M_1_14_1_0, StringComparison.CurrentCultureIgnoreCase ) ? this.MagentoServiceLowLevelSoap : this.MagentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( pingres.StoreVersion, true, false );
 
-						var stockitems = await magentoServiceLowLevelSoap.GetStockItemsAsync( inventory.Select( x => x.Sku ).ToList(), scopes ?? new[] { 0, 1 } ).ConfigureAwait( false );
+						var stockitems = await magentoServiceLowLevelSoap.GetStockItemsAsync( inventory.Select( x => x.Sku ).ToList(), scopes ?? new[] { 0, 1 }, token ).ConfigureAwait( false );
 						var productsWithSkuQtyId = from i in inventory join s in stockitems.InventoryStockItems on i.Sku equals s.Sku select new Inventory() { ItemId = s.ProductId, ProductId = s.ProductId, Qty = i.Qty };
-						await this.UpdateInventoryAsync( productsWithSkuQtyId ).ConfigureAwait( false );
+						await this.UpdateInventoryAsync( productsWithSkuQtyId, token ).ConfigureAwait( false );
 					}
 					else
 					{
-						var products = await this.GetProductsAsync( scopes ?? new[] { 0, 1 } ).ConfigureAwait( false );
+						var products = await this.GetProductsAsync( token, scopes ?? new[] { 0, 1 } ).ConfigureAwait( false );
 						var productsWithSkuQtyId = from i in inventory join s in products on i.Sku equals s.Sku select new Inventory { ItemId = s.ProductId, ProductId = s.ProductId, Qty = i.Qty, Sku = s.Sku };
-						await this.UpdateInventoryAsync( productsWithSkuQtyId ).ConfigureAwait( false );
+						await this.UpdateInventoryAsync( productsWithSkuQtyId, token ).ConfigureAwait( false );
 					}
 				}
 
@@ -683,7 +684,7 @@ namespace MagentoAccess
 			return dates;
 		}
 
-		private static async Task< IEnumerable< Product > > GetProductsViaSoapAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, bool includeDetails, string productType, bool productTypeShouldBeExcluded, IEnumerable< int > scopes, DateTime? updatedFrom, IEnumerable< string > skus, bool stockItemsOnly, Mark mark = null )
+		private static async Task< IEnumerable< Product > > GetProductsViaSoapAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, bool includeDetails, string productType, bool productTypeShouldBeExcluded, IEnumerable< int > scopes, DateTime? updatedFrom, IEnumerable< string > skus, bool stockItemsOnly, CancellationToken cancellationToken, Mark mark = null )
 		{
 			const int stockItemsListMaxChunkSize = 1000;
 			SoapGetProductsResponse catalogProductListResponse;
@@ -692,19 +693,19 @@ namespace MagentoAccess
 				var magentoServiceLowLevelSoapGetProductsBySku = magentoServiceLowLevelSoap as IMagentoServiceLowLevelSoapGetProductsBySku;
 				if( magentoServiceLowLevelSoapGetProductsBySku != null )
 				{
-					catalogProductListResponse = await magentoServiceLowLevelSoapGetProductsBySku.GetProductsAsync( productType, productTypeShouldBeExcluded, updatedFrom, skus as IReadOnlyCollection< string >, mark ).ConfigureAwait( false );
+					catalogProductListResponse = await magentoServiceLowLevelSoapGetProductsBySku.GetProductsAsync( productType, productTypeShouldBeExcluded, updatedFrom, skus as IReadOnlyCollection< string >, cancellationToken, mark ).ConfigureAwait( false );
 				}
 				else
 				{
 					catalogProductListResponse = new SoapGetProductsResponse
 					{
-						Products = await GetProductsBySkusViaRestAsync( magentoServiceLowLevelSoap, skus, mark )
+						Products = await GetProductsBySkusViaRestAsync( magentoServiceLowLevelSoap, skus, cancellationToken, mark )
 					};
 				}
 			}
 			else
 			{
-				catalogProductListResponse = await magentoServiceLowLevelSoap.GetProductsAsync( productType, productTypeShouldBeExcluded, updatedFrom, mark ).ConfigureAwait( false );
+				catalogProductListResponse = await magentoServiceLowLevelSoap.GetProductsAsync( productType, productTypeShouldBeExcluded, updatedFrom, cancellationToken, mark ).ConfigureAwait( false );
 			}
 
 			if( catalogProductListResponse?.Products == null || !catalogProductListResponse.Products.Any() )
@@ -714,7 +715,7 @@ namespace MagentoAccess
 			List< InventoryStockItem > stockItems;
 			if( magentoServiceLowLevelSoap.GetStockItemsWithoutSkuImplementedWithPages )
 			{
-				var inventory = await magentoServiceLowLevelSoap.GetStockItemsWithoutSkuAsync( products.Select( x => x.Sku ), scopes ).ConfigureAwait( false );
+				var inventory = await magentoServiceLowLevelSoap.GetStockItemsWithoutSkuAsync( products.Select( x => x.Sku ), scopes, cancellationToken ).ConfigureAwait( false );
 				stockItems = inventory.InventoryStockItems.ToList();
 			}
 			else
@@ -732,7 +733,7 @@ namespace MagentoAccess
 				var getStockItemsAsync = new List< InventoryStockItem >();
 				foreach( var productsDevidedByChunk in productsDevidedByChunks )
 				{
-					var catalogInventoryStockItemListResponse = await magentoServiceLowLevelSoap.GetStockItemsAsync( productsDevidedByChunk.Select( x => x.Sku ).ToList(), scopes, mark ).ConfigureAwait( false );
+					var catalogInventoryStockItemListResponse = await magentoServiceLowLevelSoap.GetStockItemsAsync( productsDevidedByChunk.Select( x => x.Sku ).ToList(), scopes, cancellationToken, mark ).ConfigureAwait( false );
 					getStockItemsAsync.AddRange( catalogInventoryStockItemListResponse.InventoryStockItems.ToList() );
 				}
 				stockItems = getStockItemsAsync.ToList();
@@ -749,25 +750,25 @@ namespace MagentoAccess
 			{
 				var fillService = ( magentoServiceLowLevelSoap as IMagentoServiceLowLevelSoapFillProductsDetails );
 				if( fillService != null )
-					resultProducts = ( await fillService.FillProductDetails( resultProducts.Select( x => new ProductDetails( x ) ) ).ConfigureAwait( false ) ).Where( x => x != null ).Select( y => y.ToProduct() );
+					resultProducts = ( await fillService.FillProductDetails( resultProducts.Select( x => new ProductDetails( x ) ), cancellationToken ).ConfigureAwait( false ) ).Where( x => x != null ).Select( y => y.ToProduct() );
 			}
 			return resultProducts;
 		}
 
-		private static async Task< IEnumerable< SoapProduct > > GetProductsBySkusViaRestAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, IEnumerable< string > skus, Mark mark )
+		private static async Task< IEnumerable< SoapProduct > > GetProductsBySkusViaRestAsync( IMagentoServiceLowLevelSoap magentoServiceLowLevelSoap, IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark )
 		{
-			var products = await magentoServiceLowLevelSoap.GetProductsBySkusAsync( skus, mark ).ConfigureAwait( false );
+			var products = await magentoServiceLowLevelSoap.GetProductsBySkusAsync( skus, cancellationToken, mark ).ConfigureAwait( false );
 			if( products?.Products == null || !products.Products.Any() )
 				return new List< SoapProduct >();
 
 			return products.Products;
 		}
 
-		private async Task< string > UpdateStockItemsBySoapByThePiece( IList< Inventory > inventories, Mark mark )
+		private async Task< string > UpdateStockItemsBySoapByThePiece( IList< Inventory > inventories, CancellationToken cancellationToken, Mark mark )
 		{
 			var productToUpdate = inventories.Select( x => new PutStockItem( x ) ).ToList();
 
-			var batchResponses = await productToUpdate.ProcessInBatchAsync( 5, async x => new Tuple< bool, List< PutStockItem > >( await this.MagentoServiceLowLevelSoap.PutStockItemAsync( x, mark ).ConfigureAwait( false ), new List< PutStockItem > { x } ) ).ConfigureAwait( false );
+			var batchResponses = await productToUpdate.ProcessInBatchAsync( 5, async x => new Tuple< bool, List< PutStockItem > >( await this.MagentoServiceLowLevelSoap.PutStockItemAsync( x, cancellationToken, mark ).ConfigureAwait( false ), new List< PutStockItem > { x } ) ).ConfigureAwait( false );
 
 			var updateBriefInfo = batchResponses.Where( x => x.Item1 ).SelectMany( y => y.Item2 ).ToJson();
 
@@ -781,14 +782,14 @@ namespace MagentoAccess
 			return updateBriefInfo;
 		}
 
-		private async Task< string > UpdateStockItemsBySoap( IList< Inventory > inventories, IMagentoServiceLowLevelSoap magentoService, Mark markForLog = null )
+		private async Task< string > UpdateStockItemsBySoap( IList< Inventory > inventories, IMagentoServiceLowLevelSoap magentoService, CancellationToken cancellationToken, Mark markForLog = null )
 		{
 			const int productsUpdateMaxChunkSize = 50;
 			var productToUpdate = inventories.Select( x => new PutStockItem( x ) ).ToList();
 
 			var productsDevidedToChunks = productToUpdate.SplitToChunks( productsUpdateMaxChunkSize );
 
-			var batchResponses = await productsDevidedToChunks.ProcessInBatchAsync( 1, async x => new Tuple< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > >, List< PutStockItem > >( await magentoService.PutStockItemsAsync( x, markForLog.CreateChildOrNull() ).ConfigureAwait( false ), x ) ).ConfigureAwait( false );
+			var batchResponses = await productsDevidedToChunks.ProcessInBatchAsync( 1, async x => new Tuple< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > >, List< PutStockItem > >( await magentoService.PutStockItemsAsync( x, cancellationToken, markForLog.CreateChildOrNull() ).ConfigureAwait( false ), x ) ).ConfigureAwait( false );
 
 			var batchResponsesList = batchResponses as IList< Tuple< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > >, List< PutStockItem > > > ?? batchResponses.ToList();
 			var updateBriefInfo = batchResponsesList.SelectMany( x => x.Item1 ).Where( y => y.Response.ErrorCode == RpcInvoker.SoapErrorCode.Success ).ToJson();

--- a/src/MagentoAccess/MagentoService.cs
+++ b/src/MagentoAccess/MagentoService.cs
@@ -907,6 +907,16 @@ namespace MagentoAccess
 			}
 		}
 		
+		/// <summary>
+		///	Last service's network activity time. Can be used to monitor service's state.
+		/// </summary>
+		public DateTime LastActivityTime
+		{
+			get
+			{
+				return MagentoServiceLowLevelSoap.LastActivityTime ?? DateTime.UtcNow;
+			}
+		}
 	}
 
 	public class MagentoConfig

--- a/src/MagentoAccess/Misc/MagentoTimeouts.cs
+++ b/src/MagentoAccess/Misc/MagentoTimeouts.cs
@@ -99,7 +99,8 @@ namespace MagentoAccess.Misc
 		{
 			get
 			{
-				if ( _timeouts.TryGetValue( operation, out MagentoOperationTimeout timeout ) )
+				MagentoOperationTimeout timeout;
+				if ( _timeouts.TryGetValue( operation, out timeout ) )
 					return timeout.TimeoutInMs;
 
 				return DefaultOperationTimeout.TimeoutInMs;

--- a/src/MagentoAccess/Misc/MagentoTimeouts.cs
+++ b/src/MagentoAccess/Misc/MagentoTimeouts.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CuttingEdge.Conditions;
+
+namespace MagentoAccess.Misc
+{
+	public enum MagentoOperationEnum
+	{
+		/// <summary>
+		///	Get authorization token
+		///		API: GET /V1/integration/admin/token
+		/// </summary>
+		GetToken,
+		/// <summary>
+		///	Get orders by ids
+		///		API: GET /V1/orders?searchCriteria[filterGroups][0][filters][0][field]=increment_id
+		///						&searchCriteria[filterGroups][0][filters][0][value]={orderId},{orderId2},...
+		///						&searchCriteria[filterGroups][0][filters][0][conditionType]=in
+		/// </summary>
+		GetOrdersByIds,
+		/// <summary>
+		///	Get modified orders
+		///		API: GET /V1/orders?searchCriteria[filterGroups][0][filters][0][field]=updated_at
+		///						&searchCriteria[filterGroups][0][filters][0][value]={updatedDateFrom}
+		///						&searchCriteria[filterGroups][0][filters][0][conditionType]=from
+		///						&searchCriteria[filterGroups][1][filters][0][field]=updated_at
+		///						&searchCriteria[filterGroups][1][filters][0][value]={updatedDateTo}
+		///						&searchCriteria[filterGroups][1][filters][0][conditionType]=to
+		/// </summary>
+		GetModifiedOrders,
+		/// <summary>
+		///	Get products updated at date greater than specified
+		///		API: GET /V1/products?searchCriteria[filterGroups][0][filters][0][field]=type_id
+		///						&searchCriteria[filterGroups][0][filters][0][value]={productTypeId}
+		///						&searchCriteria[filterGroups][0][filters][0][conditionType]=eq|neq
+		///						&searchCriteria[filterGroups][1][filters][0][field]=updated_at
+		///						&searchCriteria[filterGroups][1][filters][0][value]={updatedAt}
+		///						&searchCriteria[filterGroups][1][filters][0][conditionType]=gt
+		/// </summary>
+		GetFilteredProducts,
+		/// <summary>
+		///	Get product details by sku
+		///		API: GET /V1/products/{sku}
+		/// </summary>
+		GetProductBySku,
+		/// <summary>
+		///	Get products details by skus
+		///		API: GET /V1/products?searchCriteria[filterGroups][0][filters][0][field]=sku
+		///						&searchCriteria[filterGroups][0][filters][0][value]={sku,sku2,...skuN}
+		///						&searchCriteria[filterGroups][0][filters][0][conditionType]=in
+		/// </summary>
+		GetProductsBySkus,
+		/// <summary>
+		///		API: GET /V1/categories	
+		/// </summary>
+		GetProductsCategories,
+		/// <summary>
+		///	Get products manufacturers
+		///		API: GET /V1/products/attributes/manufacturer
+		/// </summary>
+		GetProductsManufacturers,
+		/// <summary>
+		///	Get stock item's quantity
+		///		API: GET /V1/stockitems/{sku}
+		/// </summary>
+		GetStockItemQuantity,
+		/// <summary>
+		///	Update stock item's quantity
+		///		API: PUT /V1/products/{sku}/stockItems/{itemId}
+		/// </summary>
+		UpdateStockItemQuantity
+	}
+
+	public class MagentoOperationTimeout
+	{
+		public int TimeoutInMs { get; private set; }
+
+		public MagentoOperationTimeout( int timeoutInMs )
+		{
+			Condition.Requires( timeoutInMs, "timeoutInMs" ).IsGreaterThan( 0 );
+			this.TimeoutInMs = timeoutInMs;
+		}
+	}
+
+	public class MagentoTimeouts
+	{
+		public const int DefaultTimeoutInMs = 5 * 60 * 1000;
+		private Dictionary< MagentoOperationEnum, MagentoOperationTimeout > _timeouts;
+
+		/// <summary>
+		///	This timeout value will be used if specific timeout for operation is not provided. Default value can be changed through constructor.
+		/// </summary>
+		public MagentoOperationTimeout DefaultOperationTimeout { get; private set; }
+
+		public int this[ MagentoOperationEnum operation ]
+		{
+			get
+			{
+				if ( _timeouts.TryGetValue( operation, out MagentoOperationTimeout timeout ) )
+					return timeout.TimeoutInMs;
+
+				return DefaultOperationTimeout.TimeoutInMs;
+			}
+		}
+
+		public void Set( MagentoOperationEnum operation, MagentoOperationTimeout timeout )
+		{
+			_timeouts[ operation ] = timeout;
+		}
+
+		public MagentoTimeouts( int defaultTimeoutInMs )
+		{
+			_timeouts = new Dictionary< MagentoOperationEnum, MagentoOperationTimeout >();
+			this.DefaultOperationTimeout = new MagentoOperationTimeout( defaultTimeoutInMs );
+		}
+
+		public MagentoTimeouts() : this( DefaultTimeoutInMs ) { }
+	}
+}

--- a/src/MagentoAccess/Models/GetOrders/Item.cs
+++ b/src/MagentoAccess/Models/GetOrders/Item.cs
@@ -22,7 +22,7 @@ namespace MagentoAccess.Models.GetOrders
 		public decimal TaxPercent { get; set; }
 		public decimal TaxAmount { get; set; }
 		public decimal BaseTaxAmount { get; set; }
-		public decimal DscountAmount { get; set; }
+		public decimal DiscountAmount { get; set; }
 		public decimal BaseDiscountAmount { get; set; }
 		public decimal RowTotal { get; set; }
 		public decimal BaseRowTotal { get; set; }
@@ -64,7 +64,7 @@ namespace MagentoAccess.Models.GetOrders
 			          && Equals( this.TaxPercent, item.TaxPercent )
 			          && Equals( this.TaxAmount, item.TaxAmount )
 			          && Equals( this.BaseTaxAmount, item.BaseTaxAmount )
-			          && Equals( this.DscountAmount, item.DscountAmount )
+			          && Equals( this.DiscountAmount, item.DiscountAmount )
 			          && Equals( this.BaseDiscountAmount, item.BaseDiscountAmount )
 			          && Equals( this.RowTotal, item.RowTotal )
 			          && Equals( this.BaseRowTotal, item.BaseRowTotal )

--- a/src/MagentoAccess/Models/GetOrders/Order.cs
+++ b/src/MagentoAccess/Models/GetOrders/Order.cs
@@ -107,30 +107,7 @@ namespace MagentoAccess.Models.GetOrders
 			this.GrandTotal = order.GrandTotal.ToDecimalOrDefault();
 			this.OrderIncrementalId = order.IncrementId;
 			this.OrderId = order.OrderId;
-			this.Items = order.Items.Select( x => new Item
-				{
-					BaseDiscountAmount = x.BaseDiscountAmount.ToDecimalOrDefault(),
-					BaseOriginalPrice = x.BaseOriginalPrice.ToDecimalOrDefault(),
-					Sku = x.Sku,
-					Name = x.Name,
-					BaseTaxAmount = x.BaseTaxAmount.ToDecimalOrDefault(),
-					ItemId = x.ItemId,
-					BasePrice = x.BasePrice.ToDecimalOrDefault(),
-					BaseRowTotal = x.BaseRowTotal.ToDecimalOrDefault(),
-					DscountAmount = x.DiscountAmount.ToDecimalOrDefault(),
-					OriginalPrice = x.OriginalPrice.ToDecimalOrDefault(),
-					Price = x.Price.ToDecimalOrDefault(),
-					ProductType = x.ProductType,
-					QtyCanceled = x.QtyCanceled.ToDecimalOrDefault(),
-					QtyInvoiced = x.QtyInvoiced.ToDecimalOrDefault(),
-					QtyOrdered = x.QtyOrdered.ToDecimalOrDefault(),
-					QtyShipped = x.QtyShipped.ToDecimalOrDefault(),
-					QtyRefunded = x.QtyRefunded.ToDecimalOrDefault(),
-					RowTotal = x.RowTotal.ToDecimalOrDefault(),
-					TaxAmount = x.TaxAmount.ToDecimalOrDefault(),
-					TaxPercent = x.TaxPercent.ToDecimalOrDefault(),
-				}
-			).ToList();
+			this.Items = order.Items.ToSvOrderItems().ToList();
 			this.PaymentMethod = order.Payment?.Method;
 			this.StoreName = order.StoreName;
 			this.Subtotal = order.Subtotal.ToDecimalOrDefault();
@@ -212,7 +189,7 @@ namespace MagentoAccess.Models.GetOrders
 					ItemId = x.item_id,
 					BasePrice = x.base_price.ToDecimalOrDefault(),
 					BaseRowTotal = x.base_row_total.ToDecimalOrDefault(),
-					DscountAmount = x.discount_amount.ToDecimalOrDefault(),
+					DiscountAmount = x.discount_amount.ToDecimalOrDefault(),
 					OriginalPrice = x.original_price.ToDecimalOrDefault(),
 					Price = x.price.ToDecimalOrDefault(),
 					ProductType = x.product_type,
@@ -453,6 +430,36 @@ namespace MagentoAccess.Models.GetOrders
 			var conntinueFlag = true;
 			conntinueFlag = o1Sorted.SequenceEqual( o2Sorted );
 			return conntinueFlag;
+		}
+
+		internal static IEnumerable< Item > ToSvOrderItems( this IEnumerable< OrderItemEntity > items )
+		{
+			if ( items == null )
+				return new List< Item >();
+			return items.Select( x => new Item
+				{
+					BaseDiscountAmount = x.BaseDiscountAmount.ToDecimalOrDefault(),
+					BaseOriginalPrice = x.BaseOriginalPrice.ToDecimalOrDefault(),
+					Sku = x.Sku,
+					Name = x.Name,
+					BaseTaxAmount = x.BaseTaxAmount.ToDecimalOrDefault(),
+					ItemId = x.ItemId,
+					BasePrice = x.BasePrice.ToDecimalOrDefault(),
+					BaseRowTotal = x.BaseRowTotal.ToDecimalOrDefault(),
+					DiscountAmount = x.DiscountAmount.ToDecimalOrDefault(),
+					OriginalPrice = x.OriginalPrice.ToDecimalOrDefault(),
+					Price = x.Price.ToDecimalOrDefault(),
+					ProductType = x.ProductType,
+					QtyCanceled = x.QtyCanceled.ToDecimalOrDefault(),
+					QtyInvoiced = x.QtyInvoiced.ToDecimalOrDefault(),
+					QtyOrdered = x.QtyOrdered.ToDecimalOrDefault(),
+					QtyShipped = x.QtyShipped.ToDecimalOrDefault(),
+					QtyRefunded = x.QtyRefunded.ToDecimalOrDefault(),
+					RowTotal = x.RowTotal.ToDecimalOrDefault(),
+					TaxAmount = x.TaxAmount.ToDecimalOrDefault(),
+					TaxPercent = x.TaxPercent.ToDecimalOrDefault()
+				}
+			);
 		}
 	}
 }

--- a/src/MagentoAccess/Models/GetShipments/Shipment.cs
+++ b/src/MagentoAccess/Models/GetShipments/Shipment.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using MagentoAccess.Models.Services.Rest.v2x.SalesOrderRepository;
+
+namespace MagentoAccess.Models.GetShipments
+{
+	public class Shipment
+	{
+		public string Id { get; set; }
+		public string OrderId { get; set; }
+		public string OrderIncrementId { get; set; }
+		public DateTime CreatedAtUtc { get; set; }
+		public IEnumerable< ShipmentItem > Items { get; set; }
+		public string Carrier { get; set; }
+		public string TrackingNumber { get; set; }
+		public string Note { get; set; }
+
+		public Shipment()
+		{
+		}
+
+		internal Shipment( ShipmentResponse response )
+		{
+			this.Id = response.Id;
+			this.OrderId = response.OrderId;
+			this.OrderIncrementId = response.OrderIncrementId;
+			this.CreatedAtUtc = response.CreatedAt;
+			this.Items = response.Items?.Select( i => new ShipmentItem( i ) )?.ToList() ?? new List< ShipmentItem >();
+
+			var trackingInfo = response.Tracks;
+			if ( trackingInfo != null && trackingInfo.Any() )
+			{
+				this.Carrier = trackingInfo.First().Title;
+				this.TrackingNumber = trackingInfo.First().TrackingNumber;
+			}
+
+			if ( response.Comments != null && response.Comments.Any() )
+			{
+				this.Note = response.Comments.OrderByDescending( c => c.CreatedAt ).First().Comment;
+			}
+		}
+	}
+
+	public class ShipmentItem
+	{
+		public string Sku { get; set; }
+		public int Quantity { get; set; }
+		public decimal? Weight { get; set; }
+
+		public ShipmentItem()
+		{
+		}
+
+		internal ShipmentItem( ShipmentResponseItem item )
+		{
+			this.Sku = item.Sku;
+			this.Quantity = item.Quantity ?? 0;
+			this.Weight = item.Weight;
+		}
+	}
+}

--- a/src/MagentoAccess/Models/Services/Rest/v2x/SalesOrderRepository/ShipmentsResponse.cs
+++ b/src/MagentoAccess/Models/Services/Rest/v2x/SalesOrderRepository/ShipmentsResponse.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace MagentoAccess.Models.Services.Rest.v2x.SalesOrderRepository
+{
+	[ DataContract ]
+	public class ShipmentsResponse
+	{
+		[ DataMember( Name = "items" ) ]
+		public IEnumerable< ShipmentResponse > Items { get; set; }
+
+		[ DataMember( Name = "total_count" ) ]
+		public int TotalCount { get; set; }
+	}
+
+	[ DataContract ]
+	public class ShipmentResponse
+	{
+		[ DataMember( Name = "created_at" ) ]
+		public DateTime CreatedAt { get; set; }
+
+		[ DataMember( Name = "updated_at" ) ]
+		public DateTime UpdatedAt { get; set; }
+
+		[ DataMember( Name = "entity_id" ) ]
+		public long EntityId { get; set; }
+
+		[ DataMember( Name = "increment_id" ) ]
+		public string Id { get; set; }
+
+		[ DataMember( Name = "order_id" ) ]
+		public string OrderId { get; set; }
+
+		public string OrderIncrementId { get; set; }
+
+		[ DataMember( Name = "items" ) ]
+		public IEnumerable< ShipmentResponseItem > Items { get; set; }
+
+		[ DataMember( Name = "tracks" ) ]
+		public IEnumerable< ShipmentResponseTrack > Tracks { get; set; }
+
+		[ DataMember( Name = "comments" ) ]
+		public IEnumerable< ShipmentResponseComment > Comments { get; set; }
+	}
+
+	[ DataContract ]
+	public class ShipmentResponseItem
+	{
+		[ DataMember( Name = "name" ) ]
+		public string Name { get; set; }
+
+		[ DataMember( Name = "price" ) ]
+		public decimal? Price { get; set; }
+
+		[ DataMember( Name = "sku" ) ]
+		public string Sku { get; set; }
+
+		[ DataMember( Name = "weight" ) ]
+		public decimal? Weight { get; set; } 
+
+		[ DataMember( Name = "qty" ) ]
+		public int? Quantity { get; set; }
+	}
+
+	[ DataContract ]
+	public class ShipmentResponseTrack
+	{
+		[ DataMember( Name = "order_id" ) ]
+		public long OrderId { get; set; }
+		
+		[ DataMember( Name = "created_at" ) ]
+		public DateTime CreatedAt { get; set; }
+		
+		[ DataMember( Name = "updated_at" ) ]
+		public DateTime UpdatedAt { get; set; }
+		
+		[ DataMember( Name = "track_number" ) ]
+		public string TrackingNumber { get; set; }
+		
+		[ DataMember( Name = "title" ) ]
+		public string Title { get; set; }
+		
+		[ DataMember( Name = "carrier_code" ) ]
+		public string CarrierCode { get; set; }
+	}
+
+	public class ShipmentResponseComment
+	{
+		[ DataMember( Name = "created_at" ) ]
+		public DateTime CreatedAt { get; set; }
+		
+		[ DataMember( Name = "comment" ) ]
+		public string Comment { get; set; }
+	}
+}

--- a/src/MagentoAccess/Models/Services/SOAP/GetOrders/OrderInfoResponse.cs
+++ b/src/MagentoAccess/Models/Services/SOAP/GetOrders/OrderInfoResponse.cs
@@ -1019,7 +1019,7 @@ namespace MagentoAccess.Models.Services.Soap.GetOrders
 		public string Weight { get; private set; }
 	}
 
-	internal class OrderItemEntity
+	public class OrderItemEntity
 	{
 		public OrderItemEntity( )
 		{
@@ -1333,6 +1333,15 @@ namespace MagentoAccess.Models.Services.Soap.GetOrders
 		public OrderItemEntity( TsZoey_v_1_9_0_1_CE.salesOrderItemEntity salesOrderItemEntity )
 		{
 			Mapper.Map< TsZoey_v_1_9_0_1_CE.salesOrderItemEntity, OrderItemEntity >( salesOrderItemEntity, this );
+		}
+
+		public OrderItemEntity( TsZoey_v_1_9_0_1_CE.salesOrderInvoiceItemEntity salesOrderInvoiceItemEntity, string discountAmount )
+		{
+			this.Price = salesOrderInvoiceItemEntity.price;
+			this.QtyOrdered = salesOrderInvoiceItemEntity.qty;
+			this.Sku = salesOrderInvoiceItemEntity.sku;
+			this.DiscountAmount = discountAmount;
+			this.TaxAmount = salesOrderInvoiceItemEntity.tax_amount;
 		}
 
 		public string OrderId { get; set; }

--- a/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Magento.wsdl
+++ b/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Magento.wsdl
@@ -2590,6 +2590,8 @@
           <xsd:element minOccurs="0" name="telephone" type="xsd:string" />
           <xsd:element minOccurs="0" name="postcode" type="xsd:string" />
           <xsd:element minOccurs="0" name="zoey_order_comment" type="xsd:string" />
+          <xsd:element minOccurs="0" name="order_invoices" type="typens:salesOrderInvoiceEntityArray" />
+          <xsd:element minOccurs="0" name="order_shipments" type="typens:salesOrderShipmentEntityArray" />
         </xsd:sequence>
       </xsd:complexType>
       <xsd:complexType name="salesOrderListEntityArray">

--- a/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Reference.cs
+++ b/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Reference.cs
@@ -15100,6 +15100,10 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
         
         private string zoey_order_commentField;
         
+        private salesOrderInvoiceEntity[] order_invoicesField;
+        
+        private salesOrderShipmentEntity[] order_shipmentsField;
+        
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=0)]
         public string increment_id {
@@ -17153,7 +17157,7 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=171)]
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=172)]
         public string zoey_order_comment {
             get {
                 return this.zoey_order_commentField;
@@ -17161,6 +17165,32 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
             set {
                 this.zoey_order_commentField = value;
                 this.RaisePropertyChanged("zoey_order_comment");
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=176)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("complexObjectArray", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, IsNullable=false)]
+        public salesOrderInvoiceEntity[] order_invoices {
+            get {
+                return this.order_invoicesField;
+            }
+            set {
+                this.order_invoicesField = value;
+                this.RaisePropertyChanged("order_invoices");
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=177)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("complexObjectArray", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, IsNullable=false)]
+        public salesOrderShipmentEntity[] order_shipments {
+            get {
+                return this.order_shipmentsField;
+            }
+            set {
+                this.order_shipmentsField = value;
+                this.RaisePropertyChanged("order_shipments");
             }
         }
         
@@ -18869,7 +18899,7 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
         private salesOrderStatusHistoryEntity[] status_historyField;
         
         private string zoey_order_commentField;
-        
+
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=0)]
         public string increment_id {
@@ -19747,7 +19777,7 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
                 this.RaisePropertyChanged("zoey_order_comment");
             }
         }
-        
+               
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
         
         protected void RaisePropertyChanged(string propertyName) {

--- a/src/MagentoAccess/Services/IWebRequestServices.cs
+++ b/src/MagentoAccess/Services/IWebRequestServices.cs
@@ -1,22 +1,11 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Net;
+﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
-using MagentoAccess.Misc;
-using Netco.Logging;
 
 namespace MagentoAccess.Services
 {
 	internal interface IWebRequestServices
 	{
-		Stream GetResponseStream( WebRequest webRequest );
-
-		Task< Stream > GetResponseStreamAsync( WebRequest webRequest, Mark mark = null );
-
-		WebRequest CreateServiceGetRequest( string serviceUrl, Dictionary< string, string > rawUrlParameters );
-
-		Task< WebRequest > CreateServiceGetRequestAsync( string serviceUrl, string body, Dictionary< string, string > rawHeaders );
-
-		void PopulateRequestByBody( string body, HttpWebRequest webRequest );
+		Task< Stream > GetResponseStreamAsync( string method, string url, string authorizationToken, CancellationToken cancellationToken, string body = null, int? operationTimeout = null );
 	}
 }

--- a/src/MagentoAccess/Services/IWebRequestServices.cs
+++ b/src/MagentoAccess/Services/IWebRequestServices.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -6,6 +7,6 @@ namespace MagentoAccess.Services
 {
 	internal interface IWebRequestServices
 	{
-		Task< Stream > GetResponseStreamAsync( string method, string url, string authorizationToken, CancellationToken cancellationToken, string body = null, int? operationTimeout = null );
+		Task< Stream > GetResponseStreamAsync( string method, string url, string authorizationToken, CancellationToken cancellationToken, string body = null, int? operationTimeout = null, Action< string > logClientHeaders = null );
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,17 @@ namespace MagentoAccess.Services.Rest.v2x
 
 		public string GetServiceVersion(){
 			return MagentoVersions.MR_2_0_0_0;
+		}
+
+		public DateTime? LastActivityTime
+		{
+			get 
+			{ 
+				return new[] { ProductRepository?.LastNetworkActivityTime, 
+								IntegrationAdminTokenRepository?.LastNetworkActivityTime,
+								CatalogStockItemRepository?.LastNetworkActivityTime,
+								SalesOrderRepository?.LastNetworkActivityTime }.Max() ?? DateTime.UtcNow; 
+			}
 		}
 
 		public async Task< bool > InitAsync( bool supressExceptions = false )

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel.cs
@@ -23,6 +23,8 @@ namespace MagentoAccess.Services.Rest.v2x
 		public string Store { get; }
 		public bool LogRawMessages { get; }
 		public string StoreVersion { get; set; }
+		public MagentoTimeouts OperationsTimeouts { get; set; }
+		
 		protected IProductRepository ProductRepository { get; set; }
 		protected IntegrationAdminTokenRepository IntegrationAdminTokenRepository { get; set; }
 		protected ICatalogStockItemRepository CatalogStockItemRepository { get; set; }
@@ -44,7 +46,7 @@ namespace MagentoAccess.Services.Rest.v2x
 				if( this.IntegrationAdminTokenRepository != null )
 					return true;
 
-				this.IntegrationAdminTokenRepository = new IntegrationAdminTokenRepository( MagentoUrl.Create( this.Store ) );
+				this.IntegrationAdminTokenRepository = new IntegrationAdminTokenRepository( MagentoUrl.Create( this.Store ), this.OperationsTimeouts );
 				await this.ReauthorizeAsync().ConfigureAwait( false );
 				return true;
 			}
@@ -103,21 +105,22 @@ namespace MagentoAccess.Services.Rest.v2x
 				} );
 		}
 
-		public MagentoServiceLowLevel( string soapApiUser, string soapApiKey, string baseMagentoUrl, bool logRawMessages ):this()
+		public MagentoServiceLowLevel( string soapApiUser, string soapApiKey, string baseMagentoUrl, MagentoTimeouts operationsTimeouts, bool logRawMessages ):this()
 		{
 			this.ApiUser = soapApiUser;
 			this.ApiKey = soapApiKey;
 			this.Store = baseMagentoUrl;
+			this.OperationsTimeouts = operationsTimeouts;
 			this.LogRawMessages = logRawMessages;
 		}
 
 		protected async Task ReauthorizeAsync()
 		{
-			var newToken = await this.IntegrationAdminTokenRepository.GetTokenAsync( MagentoLogin.Create( this.ApiUser ), MagentoPass.Create( this.ApiKey ) ).ConfigureAwait( false );
+			var newToken = await this.IntegrationAdminTokenRepository.GetTokenAsync( MagentoLogin.Create( this.ApiUser ), MagentoPass.Create( this.ApiKey ), CancellationToken.None ).ConfigureAwait( false );
 			var magentoUrl = MagentoUrl.Create( this.Store );
-			this.ProductRepository = new ProductRepository( newToken, magentoUrl );
-			this.CatalogStockItemRepository = new CatalogStockItemRepository( newToken, magentoUrl );
-			this.SalesOrderRepository = new SalesOrderRepositoryV1( newToken, magentoUrl );
+			this.ProductRepository = new ProductRepository( newToken, magentoUrl, OperationsTimeouts );
+			this.CatalogStockItemRepository = new CatalogStockItemRepository( newToken, magentoUrl, OperationsTimeouts );
+			this.SalesOrderRepository = new SalesOrderRepositoryV1( newToken, magentoUrl, OperationsTimeouts );
 		}
 
 		public bool GetStockItemsWithoutSkuImplementedWithPages => false;
@@ -126,7 +129,7 @@ namespace MagentoAccess.Services.Rest.v2x
 
 		public bool GetOrdersUsesEntityInsteadOfIncrementId => true;
 
-		public async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
@@ -135,8 +138,8 @@ namespace MagentoAccess.Services.Rest.v2x
 					if ( this.ProductRepository == null || this.SalesOrderRepository == null )
 						await ReauthorizeAsync().ConfigureAwait( false );
 
-					var task1 = this.ProductRepository.GetProductsAsync( DateTime.UtcNow, mark );
-					var task2 = this.SalesOrderRepository.GetOrdersAsync( DateTime.UtcNow.AddMinutes( -1 ), DateTime.UtcNow, new PagingModel( 10, 1 ), mark );
+					var task1 = this.ProductRepository.GetProductsAsync( DateTime.UtcNow, cancellationToken, mark );
+					var task2 = this.SalesOrderRepository.GetOrdersAsync( DateTime.UtcNow.AddMinutes( -1 ), DateTime.UtcNow, new PagingModel( 10, 1 ), cancellationToken, mark );
 					await Task.WhenAll( task1, task2 ).ConfigureAwait( false );
 					return new GetMagentoInfoResponse( "R2.0.0.0", "CE", this.GetServiceVersion() );
 				}
@@ -154,42 +157,42 @@ namespace MagentoAccess.Services.Rest.v2x
 			return null;
 		}
 
-		public Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+		public Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 		{
 			return null;
 		}
 
-		public Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+		public Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 		{
 			return null;
 		}
 
-		public Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+		public Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 		{
 			return null;
 		}
 
-		public Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+		public Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			return null;
 		}
 
-		public Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+		public Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			return null;
 		}
 
-		public Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+		public Task< GetSessionIdResponse > GetSessionId( CancellationToken cancellationToken, bool throwException = true )
 		{
 			return null;
 		}
 
-		public Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( string rootCategory = "1" )
+		public Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( CancellationToken cancellationToken, string rootCategory = "1" )
 		{
 			return null;
 		}
 
-		public Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute )
+		public Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute, CancellationToken cancellationToken )
 		{
 			return null;
 		}

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory.cs
@@ -1,17 +1,19 @@
 ﻿using MagentoAccess.Models.Credentials;
 using MagentoAccess.Services.Soap;
 using MagentoAccess.Services.Soap._2_1_0_0_ce;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Rest.v2x
 {
 	internal class MagentoServiceLowLevelSoap_v_r_2_0_0_0_ce_Factory : IMagentoServiceLowLevelSoapFactory
 	{
-		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config )
+		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			return new MagentoServiceLowLevel(
 				credentials.SoapApiUser,
 				credentials.SoapApiKey,
 				credentials.BaseMagentoUrl,
+				operationsTimeouts,
 				credentials.LogRawMessages
 				);
 		}

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Inventory.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Inventory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using MagentoAccess.Misc;
@@ -14,33 +15,34 @@ namespace MagentoAccess.Services.Rest.v2x
 {
 	internal partial class MagentoServiceLowLevel : IMagentoServiceLowLevelSoap
 	{
-		public async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
-				var products = await this.CatalogStockItemRepository.GetStockItemsAsync( skusOrIds, mark ).ConfigureAwait( false );
+				var products = await this.CatalogStockItemRepository.GetStockItemsAsync( skusOrIds, cancellationToken, mark ).ConfigureAwait( false );
 				var inventoryStockItems = products.Where( p => p.qty != null ).Select( Mapper.Map< InventoryStockItem > ).ToList();
 				return new InventoryStockItemListResponse( inventoryStockItems );
 			} );
 		}
 
-		public async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark = null )
+		public async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
 				var products = await this.CatalogStockItemRepository.PutStockItemsAsync(
 					stockItems.Select( x => Tuple.Create( x.Sku, x.ItemId, new RootObject() { stockItem = new StockItem { qty = x.Qty, minQty = x.MinQty, isInStock = x.Qty > 0 } } ) ),
+					cancellationToken,
 					mark ).ConfigureAwait( false );
 				return products.Select( x => new RpcInvoker.RpcRequestResponse< PutStockItem, object >( ( PutStockItem )null, new RpcInvoker.RpcResponse< object >( RpcInvoker.SoapErrorCode.Success, x, null ) ) );
 			} );
 		}
 
-		public Task< bool > PutStockItemAsync( PutStockItem putStockItem, Mark markForLog )
+		public Task< bool > PutStockItemAsync( PutStockItem putStockItem, CancellationToken cancellationToken, Mark markForLog )
 		{
 			return null;
 		}
 
-		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Orders.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Orders.cs
@@ -8,11 +8,14 @@ using MagentoAccess.Models.Services.Soap.GetOrders;
 using MagentoAccess.Services.Soap;
 using Netco.Extensions;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Rest.v2x
 {
 	internal partial class MagentoServiceLowLevel : IMagentoServiceLowLevelSoap
 	{
+		private const int ShipmentsPerPage = 100;
+
 		public async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
@@ -30,7 +33,7 @@ namespace MagentoAccess.Services.Rest.v2x
 			} );
 		}
 
-		public async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
@@ -38,7 +41,7 @@ namespace MagentoAccess.Services.Rest.v2x
 				var page = new PagingModel( itemsPerPage, 1 );
 				var pagesData = page.GetPages( ordersIds );
 				var pages = pagesData.Select( ( x, i ) => Tuple.Create( new PagingModel( itemsPerPage, i ), x ) );
-				var sales = await pages.ProcessInBatchAsync( 4, async x => await this.SalesOrderRepository.GetOrdersAsync( x.Item2, x.Item1, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
+				var sales = await pages.ProcessInBatchAsync( 4, async x => await this.SalesOrderRepository.GetOrdersAsync( x.Item2, x.Item1, cancellationToken, searchField ).ConfigureAwait( false ) ).ConfigureAwait( false );
 				var result = Enumerable.ToList( sales );
 
 				return new GetOrdersResponse( result.ToArray() );
@@ -54,6 +57,28 @@ namespace MagentoAccess.Services.Rest.v2x
 		public Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
 			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
+		}
+
+		public async Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
+		{
+			return await this.RepeatOnAuthProblemAsync.Get( async () =>
+			{
+				var result = new Dictionary< string, IEnumerable< Shipment > >();
+				var page = new PagingModel( ShipmentsPerPage, 1 );
+				var shipmentsFirstPage = await this.SalesOrderRepository.GetOrdersShipmentsAsync( modifiedFrom, modifiedTo, page, cancellationToken, mark ).ConfigureAwait( false );
+
+				var pages = page.GetPages( shipmentsFirstPage.TotalCount ).Select( pageIndex => new PagingModel( ShipmentsPerPage, pageIndex ) );
+				var shipmentsPages = await pages.ProcessInBatchAsync( 4, async pageIndex => await this.SalesOrderRepository.GetOrdersShipmentsAsync( modifiedFrom, modifiedTo, pageIndex, cancellationToken, mark ).ConfigureAwait( false ) ).ConfigureAwait( false );
+
+				var shipments = shipmentsPages.Where( sp => sp.Items != null ).SelectMany( sp => sp.Items ).ToList();
+				shipments.AddRange( shipmentsFirstPage.Items );
+
+				var ordersIds = shipments.Select( s => s.OrderId ).Distinct();
+				var orders = await this.GetOrdersAsync( ordersIds, cancellationToken, "entity_id" ).ConfigureAwait( false );
+				shipments = orders.Orders.Join( shipments, o => o.OrderId, s => s.OrderId, ( order, shipment ) => { shipment.OrderIncrementId = order.incrementId; return shipment; } ).ToList();
+
+				return shipments.Select( s => new Shipment( s ) ).GroupBy( shipment => shipment.OrderIncrementId ).ToDictionary( gr => gr.Key, gr => gr.AsEnumerable() );
+			} );
 		}
 
 		public Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Orders.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Orders.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Soap.GetOrders;
@@ -12,15 +13,15 @@ namespace MagentoAccess.Services.Rest.v2x
 {
 	internal partial class MagentoServiceLowLevel : IMagentoServiceLowLevelSoap
 	{
-		public async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
 				const int itemsPerPage = 100;
 				var page = new PagingModel( itemsPerPage, 1 );
-				var sale = await this.SalesOrderRepository.GetOrdersAsync( modifiedFrom, modifiedTo, page, mark ).ConfigureAwait( false );
+				var sale = await this.SalesOrderRepository.GetOrdersAsync( modifiedFrom, modifiedTo, page, cancellationToken, mark ).ConfigureAwait( false );
 				var pages = page.GetPages( sale.total_count ).Select( x => new PagingModel( itemsPerPage, x ) );
-				var sales = await pages.ProcessInBatchAsync( 4, async x => await this.SalesOrderRepository.GetOrdersAsync( modifiedFrom, modifiedTo, x, mark ).ConfigureAwait( false ) ).ConfigureAwait( false );
+				var sales = await pages.ProcessInBatchAsync( 4, async x => await this.SalesOrderRepository.GetOrdersAsync( modifiedFrom, modifiedTo, x, cancellationToken, mark ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 				var result = sales.ToList();
 				result.Add( sale );
@@ -29,7 +30,7 @@ namespace MagentoAccess.Services.Rest.v2x
 			} );
 		}
 
-		public async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
@@ -37,30 +38,30 @@ namespace MagentoAccess.Services.Rest.v2x
 				var page = new PagingModel( itemsPerPage, 1 );
 				var pagesData = page.GetPages( ordersIds );
 				var pages = pagesData.Select( ( x, i ) => Tuple.Create( new PagingModel( itemsPerPage, i ), x ) );
-				var sales = await pages.ProcessInBatchAsync( 4, async x => await this.SalesOrderRepository.GetOrdersAsync( x.Item2, x.Item1 ).ConfigureAwait( false ) ).ConfigureAwait( false );
+				var sales = await pages.ProcessInBatchAsync( 4, async x => await this.SalesOrderRepository.GetOrdersAsync( x.Item2, x.Item1, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
 				var result = Enumerable.ToList( sales );
 
 				return new GetOrdersResponse( result.ToArray() );
 			} );
 		}
 
-		public async Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+		public async Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 		{
-			var orderAsync = await this.SalesOrderRepository.GetOrdersAsync( new List< string > { incrementId }, new PagingModel( 1, 1 ) ).ConfigureAwait( false );
+			var orderAsync = await this.SalesOrderRepository.GetOrdersAsync( new List< string > { incrementId }, new PagingModel( 1, 1 ), cancellationToken ).ConfigureAwait( false );
 			return new OrderInfoResponse( orderAsync.items.FirstOrDefault() );
 		}
 
-		public Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark )
+		public Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
-			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, childMark );
+			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
 		}
 
-		public Task< string > CreateOrder( int shoppingcartid, string store )
+		public Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 		{
 			return null;
 		}
 
-		public Task< int > CreateCart( string storeid )
+		public Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 		{
 			return null;
 		}

--- a/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Products.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/MagentoServiceLowLevel_Products.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Models.GetProducts;
 using MagentoAccess.Models.Services.Rest.v2x.Products;
@@ -18,52 +19,52 @@ namespace MagentoAccess.Services.Rest.v2x
 	{
 		private const string ImagePath = "/pub/media/catalog/product";
 		
-		public async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null )
+		public async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
-				var products = await this.ProductRepository.GetProductsAsync( updatedFrom ?? DateTime.MinValue, productType, productTypeShouldBeExcluded, mark ).ConfigureAwait( false );
+				var products = await this.ProductRepository.GetProductsAsync( updatedFrom ?? DateTime.MinValue, productType, productTypeShouldBeExcluded, cancellationToken, mark ).ConfigureAwait( false );
 				return new SoapGetProductsResponse( products.SelectMany( x => x.items ).ToList() );
 			} );
 		}
 
-		public async Task< SoapGetProductsResponse > GetProductsBySkusAsync( IEnumerable< string > skus, Mark mark = null )
+		public async Task< SoapGetProductsResponse > GetProductsBySkusAsync( IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.RepeatOnAuthProblemAsync.Get( async () =>
 			{
-				var products = await this.ProductRepository.GetProductsBySkusAsync( skus, mark ).ConfigureAwait( false );
+				var products = await this.ProductRepository.GetProductsBySkusAsync( skus, cancellationToken, mark ).ConfigureAwait( false );
 				return new SoapGetProductsResponse( products.SelectMany( x => x.items ).ToList() );
 			} );
 		}
 
-		public Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog = null )
+		public Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog = null )
 		{
 			return null;
 		}
 
-		public Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+		public Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 		{
 			return null;
 		}
 
-		public Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest catalogProductInfoRequest, bool throwException = true )
+		public Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest catalogProductInfoRequest, CancellationToken cancellationToken, bool throwException = true )
 		{
 			return null;
 		}
 
-		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts )
+		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts, CancellationToken cancellationToken )
 		{
 			var productsList = resultProducts.ToList();
 			
 			if( !productsList.Any() )
 				return productsList;
 
-			var items = await productsList.Select( p => p.Sku ).ProcessInBatchAsync( 10, async sku => await this.ProductRepository.GetProductAsync( sku ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var items = await productsList.Select( p => p.Sku ).ProcessInBatchAsync( 10, async sku => await this.ProductRepository.GetProductAsync( sku, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
 			if( !items.Any() )
 				return productsList;
 
-			var allCategories = ( await this.ProductRepository.GetCategoriesTreeAsync().ConfigureAwait( false ) ).Flatten();
-			var allManufacturers = await this.ProductRepository.GetManufacturersAsync().ConfigureAwait( false );
+			var allCategories = ( await this.ProductRepository.GetCategoriesTreeAsync( cancellationToken ).ConfigureAwait( false ) ).Flatten();
+			var allManufacturers = await this.ProductRepository.GetManufacturersAsync( cancellationToken ).ConfigureAwait( false );
 			foreach( var product in productsList )
 			{
 				var item = items.FirstOrDefault( i => i.id.ToString() == product.ProductId );
@@ -128,7 +129,7 @@ namespace MagentoAccess.Services.Rest.v2x
 			return productsList;
 		}
 
-		public Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, bool throwException = true )
+		public Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, CancellationToken cancellationToken, bool throwException = true )
 		{
 			return null;
 		}

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
@@ -19,6 +19,8 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				{
 					case HttpStatusCode.NotFound:
 					case HttpStatusCode.BadRequest:
+					case HttpStatusCode.ServiceUnavailable:
+					case HttpStatusCode.BadGateway:
 						return true;
 					default:
 						return false;

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/BaseRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/BaseRepository.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MagentoAccess.Services.Rest.v2x.Repository
+{
+	public abstract class BaseRepository
+	{
+		private DateTime _lastNetworkActivityTime = DateTime.UtcNow;
+
+		/// <summary>
+		///	This property can be used by the client to monitor the last access library's network activity time.
+		/// </summary>
+		public DateTime LastNetworkActivityTime
+		{
+			get { return _lastNetworkActivityTime; }
+		}
+
+		protected async Task< T > TrackNetworkActivityTime< T >( Func< Task< T > > funcToTrack )
+		{
+			T result;
+
+			try
+			{
+				// before API call
+				RefreshLastNetworkActivityTime();
+				result = await funcToTrack().ConfigureAwait( false );
+			}
+			finally
+			{
+				// after getting response or exception
+				RefreshLastNetworkActivityTime();
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		///	This method is used to update service's last network activity time.
+		///	It's called every time before making API request to server or after handling the response.
+		/// </summary>
+		private  void RefreshLastNetworkActivityTime()
+		{
+			this._lastNetworkActivityTime = DateTime.UtcNow;
+		}
+	}
+}

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/CatalogStockItemRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/CatalogStockItemRepository.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace MagentoAccess.Services.Rest.v2x.Repository
 {
-	public class CatalogStockItemRepository : ICatalogStockItemRepository
+	public class CatalogStockItemRepository : BaseRepository, ICatalogStockItemRepository
 	{
 		private AuthorizationToken Token { get; }
 		private MagentoUrl Url { get; }
@@ -40,23 +40,26 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				try
+				return TrackNetworkActivityTime( async () =>
 				{
-					using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+					try
 					{
-						return JsonConvert.DeserializeObject< int >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() ) == 1;
+						using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+						{
+							return JsonConvert.DeserializeObject< int >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() ) == 1;
+						}
 					}
-				}
-				catch( MagentoWebException exception )
-				{
-					if( exception.IsNotFoundException() )
+					catch( MagentoWebException exception )
 					{
-						return false;
+						if( exception.IsNotFoundException() )
+						{
+							return false;
+						}
+						throw;
 					}
-					throw;
-				}
+				} );
 			} );
 		}
 
@@ -78,23 +81,26 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				try
+				return TrackNetworkActivityTime( async () =>
 				{
-					using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+					try
 					{
-						return JsonConvert.DeserializeObject< StockItem >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+						using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+						{
+							return JsonConvert.DeserializeObject< StockItem >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+						}
 					}
-				}
-				catch( MagentoWebException exception )
-				{
-					if( exception.IsNotFoundException() )
+					catch( MagentoWebException exception )
 					{
-						return null;
+						if( exception.IsNotFoundException() )
+						{
+							return null;
+						}
+						throw;
 					}
-					throw;
-				}
+				} );
 			} );
 		}
 

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/CatalogStockItemRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/CatalogStockItemRepository.cs
@@ -48,7 +48,8 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 					{
 						using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
 						{
-							return JsonConvert.DeserializeObject< int >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() ) == 1;
+							var response = new StreamReader( v, Encoding.UTF8 ).ReadToEnd();
+							return JsonConvert.DeserializeObject< int >( response ) > 0;
 						}
 					}
 					catch( MagentoWebException exception )

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ICatalogStockItemRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ICatalogStockItemRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Rest.v2x.CatalogStockItemRepository;
@@ -9,9 +10,9 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 {
 	public interface ICatalogStockItemRepository
 	{
-		Task< bool > PutStockItemAsync( string productSku, string itemId, RootObject stockItem, Mark mark = null );
-		Task< IEnumerable< bool > > PutStockItemsAsync( IEnumerable< Tuple< string, string, RootObject > > items, Mark mark = null );
-		Task< StockItem > GetStockItemAsync( string productSku, Mark mark = null );
-		Task< IEnumerable< StockItem > > GetStockItemsAsync( IEnumerable< string > productSku, Mark mark = null );
+		Task< bool > PutStockItemAsync( string productSku, string itemId, RootObject stockItem, CancellationToken cancellationToken, Mark mark = null );
+		Task< IEnumerable< bool > > PutStockItemsAsync( IEnumerable< Tuple< string, string, RootObject > > items, CancellationToken cancellationToken, Mark mark = null );
+		Task< StockItem > GetStockItemAsync( string productSku, CancellationToken cancellationToken, Mark mark = null );
+		Task< IEnumerable< StockItem > > GetStockItemsAsync( IEnumerable< string > productSku, CancellationToken cancellationToken, Mark mark = null );
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ICatalogStockItemRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ICatalogStockItemRepository.cs
@@ -14,5 +14,6 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 		Task< IEnumerable< bool > > PutStockItemsAsync( IEnumerable< Tuple< string, string, RootObject > > items, CancellationToken cancellationToken, Mark mark = null );
 		Task< StockItem > GetStockItemAsync( string productSku, CancellationToken cancellationToken, Mark mark = null );
 		Task< IEnumerable< StockItem > > GetStockItemsAsync( IEnumerable< string > productSku, CancellationToken cancellationToken, Mark mark = null );
+		DateTime LastNetworkActivityTime { get; }
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/IIntegrationAdminTokenRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/IIntegrationAdminTokenRepository.cs
@@ -1,10 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using MagentoAccess.Services.Rest.v2x.WebRequester;
 
 namespace MagentoAccess.Services.Rest.v2x.Repository
 {
 	public interface IIntegrationAdminTokenRepository
 	{
-		Task< AuthorizationToken > GetTokenAsync( MagentoLogin token, MagentoPass url );
+		Task< AuthorizationToken > GetTokenAsync( MagentoLogin token, MagentoPass url, CancellationToken cancellationToken );
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/IIntegrationAdminTokenRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/IIntegrationAdminTokenRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Services.Rest.v2x.WebRequester;
 
@@ -7,5 +8,6 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 	public interface IIntegrationAdminTokenRepository
 	{
 		Task< AuthorizationToken > GetTokenAsync( MagentoLogin token, MagentoPass url, CancellationToken cancellationToken );
+		DateTime LastNetworkActivityTime { get; }
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/IProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/IProductRepository.cs
@@ -22,5 +22,6 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 		Task< Item > GetProductAsync( string sku, CancellationToken cancellationToken );
 		Task< CategoryNode > GetCategoriesTreeAsync( CancellationToken cancellationToken );
 		Task< ProductAttribute > GetManufacturersAsync( CancellationToken cancellationToken );
+		DateTime LastNetworkActivityTime { get; }
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/IProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/IProductRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Rest.v2x.Products;
@@ -9,17 +10,17 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 {
 	public interface IProductRepository
 	{
-		Task< RootObject > GetProductsAsync( PagingModel page );
-		Task< List< RootObject > > GetProductsAsync();
-		Task< RootObject > GetProductsAsync( DateTime updatedAt, PagingModel page, Mark mark = null );
-		Task< RootObject > GetProductsAsync( DateTime updatedAt, string type, PagingModel page );
-		Task< RootObject > GetProductsAsync( DateTime updatedAt, string type, bool excludeType, PagingModel page, Mark mark = null );
-		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, Mark mark = null );
-		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, string type );
-		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, string type, bool excludeType, Mark mark = null );
-		Task< IEnumerable< RootObject > > GetProductsBySkusAsync( IEnumerable< string > skus, Mark mark );
-		Task< Item > GetProductAsync( string sku );
-		Task< CategoryNode > GetCategoriesTreeAsync();
-		Task< ProductAttribute > GetManufacturersAsync();
+		Task< RootObject > GetProductsAsync( PagingModel page, CancellationToken cancellationToken );
+		Task< List< RootObject > > GetProductsAsync( CancellationToken cancellationToken );
+		Task< RootObject > GetProductsAsync( DateTime updatedAt, PagingModel page, CancellationToken cancellationToken, Mark mark = null );
+		Task< RootObject > GetProductsAsync( DateTime updatedAt, string type, PagingModel page, CancellationToken cancellationToken );
+		Task< RootObject > GetProductsAsync( DateTime updatedAt, string type, bool excludeType, PagingModel page, CancellationToken cancellationToken, Mark mark = null );
+		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, CancellationToken cancellationToken, Mark mark = null );
+		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, string type, CancellationToken cancellationToken );
+		Task< List< RootObject > > GetProductsAsync( DateTime updatedAt, string type, bool excludeType, CancellationToken cancellationToken, Mark mark = null );
+		Task< IEnumerable< RootObject > > GetProductsBySkusAsync( IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark );
+		Task< Item > GetProductAsync( string sku, CancellationToken cancellationToken );
+		Task< CategoryNode > GetCategoriesTreeAsync( CancellationToken cancellationToken );
+		Task< ProductAttribute > GetManufacturersAsync( CancellationToken cancellationToken );
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ISalesOrderRepositoryV1.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ISalesOrderRepositoryV1.cs
@@ -13,5 +13,6 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 	{
 		Task< RootObject > GetOrdersAsync( IEnumerable< string > ids, PagingModel pagingModel, CancellationToken cancellationToken );
 		Task< RootObject > GetOrdersAsync( DateTime updatedFrom, DateTime updatedTo, PagingModel pagingModel, CancellationToken cancellationToken, Mark mark = null );
+		DateTime LastNetworkActivityTime { get; }
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ISalesOrderRepositoryV1.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ISalesOrderRepositoryV1.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Rest.v2x.CatalogStockItemRepository;
@@ -10,7 +11,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 {
 	public interface ISalesOrderRepositoryV1
 	{
-		Task< RootObject > GetOrdersAsync( IEnumerable< string > ids, PagingModel pagingModel );
-		Task< RootObject > GetOrdersAsync( DateTime updatedFrom, DateTime updatedTo, PagingModel pagingModel, Mark mark = null );
+		Task< RootObject > GetOrdersAsync( IEnumerable< string > ids, PagingModel pagingModel, CancellationToken cancellationToken );
+		Task< RootObject > GetOrdersAsync( DateTime updatedFrom, DateTime updatedTo, PagingModel pagingModel, CancellationToken cancellationToken, Mark mark = null );
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ISalesOrderRepositoryV1.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ISalesOrderRepositoryV1.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
-using MagentoAccess.Models.Services.Rest.v2x.CatalogStockItemRepository;
+using MagentoAccess.Models.Services.Rest.v2x.SalesOrderRepository;
 using Netco.Logging;
 using RootObject = MagentoAccess.Models.Services.Rest.v2x.SalesOrderRepository.RootObject;
 
@@ -11,8 +11,9 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 {
 	public interface ISalesOrderRepositoryV1
 	{
-		Task< RootObject > GetOrdersAsync( IEnumerable< string > ids, PagingModel pagingModel, CancellationToken cancellationToken );
+		Task< RootObject > GetOrdersAsync( IEnumerable< string > ids, PagingModel pagingModel, CancellationToken cancellationToken, string searchField = "increment_id" );
 		Task< RootObject > GetOrdersAsync( DateTime updatedFrom, DateTime updatedTo, PagingModel pagingModel, CancellationToken cancellationToken, Mark mark = null );
 		DateTime LastNetworkActivityTime { get; }
+		Task< ShipmentsResponse > GetOrdersShipmentsAsync( DateTime updatedFrom, DateTime updatedTo, PagingModel page, CancellationToken cancellationToken, Mark mark = null );
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/IntegrationAdminTokenRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/IntegrationAdminTokenRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using MagentoAccess.Services.Rest.v2x.WebRequester;
@@ -12,23 +13,26 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 	public class IntegrationAdminTokenRepository : IIntegrationAdminTokenRepository
 	{
 		private MagentoUrl Url { get; }
+		private MagentoTimeouts OperationsTimeouts { get; }
 
-		public IntegrationAdminTokenRepository( MagentoUrl url )
+		public IntegrationAdminTokenRepository( MagentoUrl url, MagentoTimeouts operationsTimeouts )
 		{
 			this.Url = url;
+			this.OperationsTimeouts = operationsTimeouts;
 		}
 
-		public async Task< AuthorizationToken > GetTokenAsync( MagentoLogin token, MagentoPass url )
+		public async Task< AuthorizationToken > GetTokenAsync( MagentoLogin token, MagentoPass url, CancellationToken cancellationToken )
 		{
 			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
 			{
 				using( var v = await ( ( WebRequest )
 					WebRequest.Create()
 						.Method( MagentoWebRequestMethod.Post )
+						.Timeout( OperationsTimeouts[ MagentoOperationEnum.GetToken ] )
 						.Url( this.Url )
 						.Path( MagentoServicePath.CreateIntegrationServicePath() )
 						.Body( JsonConvert.SerializeObject( new CredentialsModel() { username = token.Login, password = url.Password } ) ) )
-					.RunAsync( Mark.CreateNew() ).ConfigureAwait( false ) )
+					.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
 				{
 					return AuthorizationToken.Create( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
 				}

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/IntegrationAdminTokenRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/IntegrationAdminTokenRepository.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace MagentoAccess.Services.Rest.v2x.Repository
 {
-	public class IntegrationAdminTokenRepository : IIntegrationAdminTokenRepository
+	public class IntegrationAdminTokenRepository : BaseRepository, IIntegrationAdminTokenRepository
 	{
 		private MagentoUrl Url { get; }
 		private MagentoTimeouts OperationsTimeouts { get; }
@@ -23,19 +23,22 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 
 		public async Task< AuthorizationToken > GetTokenAsync( MagentoLogin token, MagentoPass url, CancellationToken cancellationToken )
 		{
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				using( var v = await ( ( WebRequest )
-					WebRequest.Create()
-						.Method( MagentoWebRequestMethod.Post )
-						.Timeout( OperationsTimeouts[ MagentoOperationEnum.GetToken ] )
-						.Url( this.Url )
-						.Path( MagentoServicePath.CreateIntegrationServicePath() )
-						.Body( JsonConvert.SerializeObject( new CredentialsModel() { username = token.Login, password = url.Password } ) ) )
-					.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+				return TrackNetworkActivityTime( async () =>
 				{
-					return AuthorizationToken.Create( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
-				}
+					using( var v = await ( ( WebRequest )
+						WebRequest.Create()
+							.Method( MagentoWebRequestMethod.Post )
+							.Timeout( OperationsTimeouts[ MagentoOperationEnum.GetToken ] )
+							.Url( this.Url )
+							.Path( MagentoServicePath.CreateIntegrationServicePath() )
+							.Body( JsonConvert.SerializeObject( new CredentialsModel() { username = token.Login, password = url.Password } ) ) )
+						.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+					{
+						return AuthorizationToken.Create( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					}
+				} );
 			} ).ConfigureAwait( false );
 		}
 

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ProductRepository.cs
@@ -17,7 +17,7 @@ using WebRequest = MagentoAccess.Services.Rest.v2x.WebRequester.WebRequest;
 
 namespace MagentoAccess.Services.Rest.v2x.Repository
 {
-	public class ProductRepository : IProductRepository
+	public class ProductRepository : BaseRepository, IProductRepository
 	{
 		private AuthorizationToken Token { get; }
 		private MagentoUrl Url { get; }
@@ -94,17 +94,20 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+				return TrackNetworkActivityTime( async () =>
 				{
-					var response = JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+					{
+						var response = JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
 					
-					if ( response.items != null )
-						response.items = response.items.Where( i => !string.IsNullOrWhiteSpace( i.sku ) ).ToList();
+						if ( response.items != null )
+							response.items = response.items.Where( i => !string.IsNullOrWhiteSpace( i.sku ) ).ToList();
 
-					return response;
-				}
+						return response;
+					}
+				} );
 			} ).ConfigureAwait( false );
 		}
 
@@ -168,23 +171,26 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				try
+				return TrackNetworkActivityTime( async () =>
 				{
-					using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+					try
 					{
-						return JsonConvert.DeserializeObject< Item >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+						using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+						{
+							return JsonConvert.DeserializeObject< Item >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+						}
 					}
-				}
-				catch( MagentoWebException exception )
-				{
-					if( exception.IsNotFoundException() )
+					catch( MagentoWebException exception )
 					{
-						return null;
+						if( exception.IsNotFoundException() )
+						{
+							return null;
+						}
+						throw;
 					}
-					throw;
-				}
+				} );
 			} );
 		}
 
@@ -229,17 +235,20 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+				return TrackNetworkActivityTime( async () => 
 				{
-					var response = JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+					{
+						var response = JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
 					
-					if ( response.items != null )
-						response.items = response.items.Where( i => !string.IsNullOrWhiteSpace( i.sku ) ).ToList();
+						if ( response.items != null )
+							response.items = response.items.Where( i => !string.IsNullOrWhiteSpace( i.sku ) ).ToList();
 
-					return response;
-				}
+						return response;
+					}
+				} );
 			} ).ConfigureAwait( false );
 		}
 
@@ -252,12 +261,15 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+				return TrackNetworkActivityTime( async () => 
 				{
-					return JsonConvert.DeserializeObject< CategoryNode >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
-				}
+					using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+					{
+						return JsonConvert.DeserializeObject< CategoryNode >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					}
+				} );
 			} );
 		}
 
@@ -270,12 +282,15 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+				return TrackNetworkActivityTime( async () => 
 				{
-					return JsonConvert.DeserializeObject< ProductAttribute >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
-				}
+					using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+					{
+						return JsonConvert.DeserializeObject< ProductAttribute >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					}
+				} );
 			} );
 		}
 	}

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/SalesOrderRepositoryV1.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/SalesOrderRepositoryV1.cs
@@ -17,7 +17,7 @@ using System.Threading;
 
 namespace MagentoAccess.Services.Rest.v2x.Repository
 {
-	public class SalesOrderRepositoryV1 : ISalesOrderRepositoryV1
+	public class SalesOrderRepositoryV1 : BaseRepository, ISalesOrderRepositoryV1
 	{
 		private AuthorizationToken Token { get; }
 		private MagentoUrl Url { get; }
@@ -60,12 +60,15 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ).ConfigureAwait( false ) )
+				return TrackNetworkActivityTime( async () =>
 				{
-					return JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
-				}
+					using( var v = await webRequest.RunAsync( cancellationToken, Mark.CreateNew() ) )
+					{
+						return JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					}
+				} );
 			} );
 		}
 
@@ -102,12 +105,15 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 				.AuthToken( this.Token )
 				.Url( this.Url );
 
-			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			return await ActionPolicies.RepeatOnChannelProblemAsync.Get( () =>
 			{
-				using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+				return TrackNetworkActivityTime( async () =>
 				{
-					return JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
-				}
+					using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+					{
+						return JsonConvert.DeserializeObject< RootObject >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+					}
+				} );
 			} ).ConfigureAwait( false );
 		}
 

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/SalesOrderRepositoryV1.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/SalesOrderRepositoryV1.cs
@@ -30,7 +30,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			this.OperationsTimeouts = operationsTimeouts;
 		}
 
-		public async Task< RootObject > GetOrdersAsync( IEnumerable< string > ids, PagingModel page, CancellationToken cancellationToken )
+		public async Task< RootObject > GetOrdersAsync( IEnumerable< string > ids, PagingModel page, CancellationToken cancellationToken, string searchField = "increment_id" )
 		{
 			var idsList = ids as IList< string > ?? ids.ToList();
 			if( ids == null || !idsList.Any() )
@@ -44,7 +44,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 					{
 						filters = new List< Filter >()
 						{
-							new Filter( "increment_id", string.Join( ",", idsList ), Filter.ConditionType.In )
+							new Filter( searchField, string.Join( ",", idsList ), Filter.ConditionType.In )
 						}
 					}
 				},
@@ -148,6 +148,47 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 			var resultItems = new List< RootObject >() { itemsFirstPage };
 			resultItems.AddRange( tailItems );
 			return resultItems;
+		}
+
+		public Task< ShipmentsResponse > GetOrdersShipmentsAsync( DateTime updatedFrom, DateTime updatedTo, PagingModel page, CancellationToken cancellationToken, Mark mark = null )
+		{
+			var parameters = new SearchCriteria()
+			{
+				filter_groups = new List< FilterGroup >()
+				{
+					new FilterGroup()
+					{
+						filters = new List< Filter >()
+						{
+							new Filter( "updated_at", updatedFrom.ToRestParameterString(), Filter.ConditionType.From )
+						}
+					},
+					new FilterGroup()
+					{
+						filters = new List< Filter >()
+						{
+							new Filter( "updated_at", updatedTo.ToRestParameterString(), Filter.ConditionType.To )
+						}
+					}
+				},
+				current_page = page.CurrentPage,
+				page_size = page.ItemsPerPage,
+			};
+
+			var webRequest = ( WebRequest )WebRequest.Create()
+				.Method( MagentoWebRequestMethod.Get )
+				.Path( MagentoServicePath.CreateShipmentsServicePath() )
+				.Parameters( parameters )
+				.AuthToken( this.Token )
+				.Url( this.Url );
+
+			return ActionPolicies.RepeatOnChannelProblemAsync.Get( async () =>
+			{
+				using( var v = await webRequest.RunAsync( cancellationToken, mark ).ConfigureAwait( false ) )
+				{
+					return JsonConvert.DeserializeObject< ShipmentsResponse >( new StreamReader( v, Encoding.UTF8 ).ReadToEnd() );
+				}
+			} );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/WebRequester/MagentoServicePath.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/WebRequester/MagentoServicePath.cs
@@ -8,6 +8,7 @@
 		public const string OrdersPath = "orders";
 		public const string ManufacturersPath = "products/attributes/manufacturer";
 		public const string IntegrationPath = "integration/admin/token";
+		public const string ShipmentsServicePath = "shipments";
 
 		public string RepositoryPath { get; private set; }
 
@@ -60,6 +61,11 @@
 		public static MagentoServicePath CreateIntegrationServicePath()
 		{
 			return Create( IntegrationPath );
+		}
+
+		public static MagentoServicePath CreateShipmentsServicePath()
+		{
+			return Create( ShipmentsServicePath );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Rest/v2x/WebRequester/WebRequest.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/WebRequester/WebRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -37,10 +38,12 @@ namespace MagentoAccess.Services.Rest.v2x.WebRequester
 			var body = this.Body.ToString();
 			var method = this.MagentoWebRequestMethod.ToString();
 
-			var clientHeaders = webRequestServices.GetCurrentHttpClientHeadersRaw();
-			MagentoLogger.LogTraceRequestMessage( $"method:'{method}',url:'{serviceUrl}',parameters:'{this.Parameters}',headers:{clientHeaders},body:'{body}', timeout:'{this.Timeout}'", mark );
+			var logClientHeadersBeforeRequest = new Action< string >( clientHeaders =>
+			{
+				MagentoLogger.LogTraceRequestMessage( $"method:'{method}',url:'{serviceUrl}',parameters:'{this.Parameters}',headers:{clientHeaders},body:'{body}', timeout:'{this.Timeout} ms'", mark );
+			} );
 
-			return webRequestServices.GetResponseStreamAsync( method, serviceUrl, this.AuthorizationToken.Token, cancellationToken, body, this.Timeout );
+			return webRequestServices.GetResponseStreamAsync( method, serviceUrl, this.AuthorizationToken.Token, cancellationToken, body, this.Timeout, logClientHeadersBeforeRequest );
 		}
 
 		public class WebRequestBuilder

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE.cs
@@ -97,7 +97,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+		public async Task< GetSessionIdResponse > GetSessionId( CancellationToken token, bool throwException = true )
 		{
 			try
 			{
@@ -212,7 +212,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			filters.complex_filter = temp.ToArray();
 		}
 
-		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, bool throwException = true )
+		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -229,7 +229,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					var attributes = new catalogProductRequestAttributes { additional_attributes = request.custAttributes ?? new string[ 0 ] };
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
@@ -244,7 +244,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, bool throwException = true )
+		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, CancellationToken cancellationToken, bool throwException = true )
 		{
 			Func< bool, Task< catalogProductAttributeMediaListResponse > > call =
 				async ( keepAlive ) =>
@@ -259,7 +259,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient, keepAlive );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogProductAttributeMediaListAsync( sessionId.SessionId, getProductAttributeMediaListRequest.ProductId, "0", "1" ).ConfigureAwait( false );
@@ -293,7 +293,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( string rootCategory = "1" )
+		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( CancellationToken cancellationToken, string rootCategory = "1" )
 		{
 			try
 			{
@@ -310,7 +310,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogCategoryTreeAsync( sessionId.SessionId, rootCategory, "0" ).ConfigureAwait( false );
@@ -324,7 +324,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute )
+		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute, CancellationToken cancellationToken )
 		{
 			try
 			{
@@ -341,7 +341,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogProductAttributeInfoAsync( sessionId.SessionId, attribute ).ConfigureAwait( false );
@@ -355,17 +355,17 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts )
+		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts, CancellationToken cancellationToken )
 		{
 			return await this.Magento1xxxHelper.FillProductDetails( resultProducts ).ConfigureAwait( false );
 		}
 
-		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}
 
-		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -384,7 +384,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogInventoryStockItemListAsync( sessionId.SessionId, skusArray ).ConfigureAwait( false );
@@ -399,7 +399,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark = null )
+		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark = null )
 		{
 			var methodParameters = stockItems.ToJson();
 			try
@@ -425,7 +425,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -449,7 +449,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, Mark markForLog )
+		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, CancellationToken cancellationToken, Mark markForLog )
 		{
 			var productsBriefInfo = new List< PutStockItem > { putStockItem }.ToJson();
 			try
@@ -471,7 +471,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -494,7 +494,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -511,7 +511,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.magentoInfoAsync( sessionId.SessionId ).ConfigureAwait( false );
@@ -528,11 +528,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 		}
 
 		#region JustForTesting
-		public async Task< int > CreateCart( string storeid )
+		public async Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartCreateAsync( sessionId.SessionId, storeid ).ConfigureAwait( false );
 
@@ -544,11 +544,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< string > CreateOrder( int shoppingcartid, string store )
+		public async Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartOrderAsync( sessionId.SessionId, shoppingcartid, store, null ).ConfigureAwait( false );
 
@@ -561,6 +561,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 		}
 
 		public async Task< int > CreateCustomer(
+			CancellationToken cancellationToken,
 			string email = "na@na.com",
 			string firstname = "firstname",
 			string lastname = "lastname",
@@ -572,7 +573,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerCustomerEntityToCreate = new customerCustomerEntityToCreate
 				{
@@ -594,11 +595,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store )
+		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cutomers = await this._magentoSoapService.customerCustomerListAsync( sessionId.SessionId, new filters() ).ConfigureAwait( false );
 
@@ -631,11 +632,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customer = new shoppingCartCustomerEntity
 				{
@@ -657,11 +658,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerAddressEntities = new shoppingCartCustomerAddressEntity[ 2 ];
 
@@ -708,11 +709,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > DeleteCustomer( int customerId )
+		public async Task< bool > DeleteCustomer( int customerId, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.customerCustomerDeleteAsync( sessionId.SessionId, customerId ).ConfigureAwait( false );
 
@@ -724,11 +725,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var shoppingCartProductEntities = new shoppingCartProductEntity[ 1 ];
 
@@ -744,11 +745,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cartPaymentMethodEntity = new shoppingCartPaymentMethodEntity
 				{
@@ -774,11 +775,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartShippingListAsync( sessionId.SessionId, shoppingCartId, store ).ConfigureAwait( false );
 
@@ -795,14 +796,14 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog )
+		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog )
 		{
 			try
 			{
 				var result = 0;
 				await ActionPolicies.GetAsync.Do( async () =>
 				{
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					var res0 = await this._magentoSoapService.catalogCategoryAttributeCurrentStoreAsync( sessionId.SessionId, storeId ).ConfigureAwait( false );
 
 					var catalogProductCreateEntity = new catalogProductCreateEntity
@@ -833,11 +834,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 				var res = await this._magentoSoapService.catalogCategoryRemoveProductAsync( sessionId.SessionId, categoryId, productId, identiferType ).ConfigureAwait( false );
 
 				//product id
@@ -866,7 +867,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
+		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, CancellationToken cancellationToken, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
 		{
 			try
 			{
@@ -876,7 +877,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 				await ActionPolicies.GetAsync.Do( async () =>
 				{
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					var temp = await ClientBaseActionRunner.RunWithAbortAsync(
 						abortAfter,

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE.cs
@@ -78,6 +78,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			return MagentoVersions.M_1_14_1_0;
 		}
 
+		public DateTime? LastActivityTime
+		{
+			get { return null; }
+		}
+
 		private void LogTraceGetResponseException( Exception exception )
 		{
 			MagentoLogger.Log().Trace( exception, "[magento] SOAP throw an exception." );

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Factory.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Factory.cs
@@ -1,10 +1,11 @@
 ﻿using MagentoAccess.Models.Credentials;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 {
 	internal class MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Factory : IMagentoServiceLowLevelSoapFactory
 	{
-		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config )
+		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			return new MagentoServiceLowLevelSoap_v_1_14_1_0_EE(
 				credentials.SoapApiUser,

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Orders.cs
@@ -8,6 +8,7 @@ using MagentoAccess.MagentoSoapServiceReference_v_1_14_1_EE;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Soap.GetOrders;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 {
@@ -61,7 +62,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField = "increment_id" )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -77,7 +78,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 					filters.complex_filter[ 1 ] = new complexFilter { key = "store_id", value = new associativeEntity { key = "in", value = this.Store } };
 				}
 
-				filters.complex_filter[ 0 ] = new complexFilter { key = "increment_id", value = new associativeEntity { key = "in", value = ordersIdsAgregated } };
+				filters.complex_filter[ 0 ] = new complexFilter { key = searchField, value = new associativeEntity { key = "in", value = ordersIdsAgregated } };
 
 				const int maxCheckCount = 2;
 				const int delayBeforeCheck = 1800000;
@@ -142,6 +143,11 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
 			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
+		}
+
+		public Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
+		{
+			return Task.FromResult( new Dictionary< string, IEnumerable< Shipment > >() );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Orders.cs
@@ -13,7 +13,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 {
 	internal partial class MagentoServiceLowLevelSoap_v_1_14_1_0_EE : IMagentoServiceLowLevelSoap
 	{
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -44,7 +44,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderListAsync( sessionId.SessionId, filters ).ConfigureAwait( false );
@@ -61,7 +61,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -93,7 +93,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderListAsync( sessionId.SessionId, filters ).ConfigureAwait( false );
@@ -107,7 +107,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 		{
 			try
 			{
@@ -125,7 +125,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
 
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderInfoAsync( sessionId.SessionId, incrementId ).ConfigureAwait( false );
@@ -139,9 +139,9 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark )
+		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
-			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, childMark );
+			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Products.cs
@@ -14,14 +14,14 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 {
 	internal partial class MagentoServiceLowLevelSoap_v_1_14_1_0_EE : IMagentoServiceLowLevelSoap, IMagentoServiceLowLevelSoapGetProductsBySku, IMagentoServiceLowLevelSoapFillProductsDetails
 	{
-		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null )
+		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
 				Func< int, int, Func< int, string >, Task< List< SoapProduct > > > productsSelector = async ( start1, count1, selector1 ) =>
 				{
 					var sourceList = Enumerable.Range( start1, count1 ).Select( selector1 ).ToList();
-					var productsResponses = await sourceList.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsAsync( productType, productTypeShouldBeExcluded, x, updatedFrom ).ConfigureAwait( false ) ).ConfigureAwait( false );
+					var productsResponses = await sourceList.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsAsync( productType, productTypeShouldBeExcluded, x, updatedFrom, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
 					var prods = productsResponses.SelectMany( x => x.Products ).ToList();
 					return prods;
 				};
@@ -38,13 +38,13 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, IReadOnlyCollection< string > skus, Mark mark = null )
+		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, IReadOnlyCollection< string > skus, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
 				var skusList = skus.ToList();
 				var skusListChunks = skusList.SplitToChunks( 10 );
-				var responses = await skusListChunks.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsPageAsync( productType, productTypeShouldBeExcluded, x, updatedFrom ).ConfigureAwait( false ) ).ConfigureAwait( false );
+				var responses = await skusListChunks.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsPageAsync( productType, productTypeShouldBeExcluded, x, updatedFrom, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
 				var soapGetProductsResponse = new SoapGetProductsResponse { Products = responses.SelectMany( x => x.Products ) };
 				return soapGetProductsResponse;
 			}
@@ -54,7 +54,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		protected virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, string productIdLike, DateTime? updatedFrom )
+		protected virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, string productIdLike, DateTime? updatedFrom, CancellationToken cancellationToken )
 
 		{
 			Func< bool, Task< catalogProductListResponse > > call = async ( keepAlive ) =>
@@ -81,7 +81,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 				privateClient = this._clientFactory.RefreshClient( privateClient, keepAlive );
 
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					res = await privateClient.catalogProductListAsync( sessionId.SessionId, filters, store ).ConfigureAwait( false );
@@ -127,7 +127,7 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 			}
 		}
 
-		protected virtual async Task< SoapGetProductsResponse > GetProductsPageAsync( string productType, bool productTypeShouldBeExcluded, IEnumerable< string > skus, DateTime? updatedFrom )
+		protected virtual async Task< SoapGetProductsResponse > GetProductsPageAsync( string productType, bool productTypeShouldBeExcluded, IEnumerable< string > skus, DateTime? updatedFrom, CancellationToken cancellationToken )
 		{
 			var inCondition = string.Join( ",", ( skus ?? Enumerable.Empty< string >() ) );
 			var filters = new filters { filter = new associativeEntity[ 0 ], complex_filter = new complexFilter[ 0 ] };
@@ -143,10 +143,10 @@ namespace MagentoAccess.Services.Soap._1_14_1_0_ee
 
 			return await this.GetWithAsync(
 				res => new SoapGetProductsResponse( res ),
-				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
+				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000, cancellationToken ).ConfigureAwait( false );
 		}
 
-		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
@@ -94,7 +94,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+		public async Task< GetSessionIdResponse > GetSessionId( CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -178,7 +178,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			filters.complex_filter = temp.ToArray();
 		}
 
-		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( string rootCategory = "1" )
+		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( CancellationToken cancellationToken, string rootCategory = "1" )
 		{
 			try
 			{
@@ -194,7 +194,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogCategoryTreeAsync( sessionId.SessionId, rootCategory, "0" ).ConfigureAwait( false );
@@ -208,7 +208,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, bool throwException = true )
+		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -224,7 +224,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogProductAttributeMediaListAsync( sessionId.SessionId, getProductAttributeMediaListRequest.ProductId, "0", "1" ).ConfigureAwait( false );
@@ -238,7 +238,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute )
+		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute, CancellationToken cancellationToken )
 		{
 			try
 			{
@@ -254,7 +254,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					try // this try catch block is crunch for 1.7
 					{
 						using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
@@ -278,17 +278,17 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts )
+		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts, CancellationToken cancellationToken )
 		{
 			return await this.Magento1xxxHelper.FillProductDetails( resultProducts ).ConfigureAwait( false );
 		}
 
-		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}
 
-		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, bool throwException = true )
+		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -305,7 +305,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 					
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					var attributes = new catalogProductRequestAttributes { additional_attributes = request.custAttributes ?? new string[ 0 ] };
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
@@ -320,7 +320,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -338,7 +338,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogInventoryStockItemListAsync( sessionId.SessionId, skusArray ).ConfigureAwait( false );
@@ -353,7 +353,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark = null )
+		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark = null )
 		{
 			var methodParameters = stockItems.ToJson();
 			try
@@ -378,7 +378,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -402,7 +402,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, Mark markForLog )
+		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, CancellationToken cancellationToken, Mark markForLog )
 		{
 			try
 			{
@@ -425,7 +425,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -449,7 +449,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 		
-		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -465,7 +465,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.magentoInfoAsync( sessionId.SessionId ).ConfigureAwait( false );
@@ -482,11 +482,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 		}
 
 		#region JustForTesting
-		public async Task< int > CreateCart( string storeid )
+		public async Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartCreateAsync( sessionId.SessionId, storeid ).ConfigureAwait( false );
 
@@ -498,11 +498,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< string > CreateOrder( int shoppingcartid, string store )
+		public async Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartOrderAsync( sessionId.SessionId, shoppingcartid, store, null ).ConfigureAwait( false );
 
@@ -515,6 +515,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 		}
 
 		public async Task< int > CreateCustomer(
+			CancellationToken cancellationToken,
 			string email = "na@na.com",
 			string firstname = "firstname",
 			string lastname = "lastname",
@@ -526,7 +527,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerCustomerEntityToCreate = new customerCustomerEntityToCreate
 				{
@@ -548,11 +549,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store )
+		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cutomers = await this._magentoSoapService.customerCustomerListAsync( sessionId.SessionId, new filters() ).ConfigureAwait( false );
 
@@ -585,11 +586,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customer = new shoppingCartCustomerEntity
 				{
@@ -611,11 +612,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerAddressEntities = new shoppingCartCustomerAddressEntity[ 2 ];
 
@@ -662,11 +663,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > DeleteCustomer( int customerId )
+		public async Task< bool > DeleteCustomer( int customerId, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.customerCustomerDeleteAsync( sessionId.SessionId, customerId ).ConfigureAwait( false );
 
@@ -678,11 +679,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var shoppingCartProductEntities = new shoppingCartProductEntity[ 1 ];
 
@@ -698,11 +699,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cartPaymentMethodEntity = new shoppingCartPaymentMethodEntity
 				{
@@ -728,11 +729,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartShippingListAsync( sessionId.SessionId, shoppingCartId, store ).ConfigureAwait( false );
 
@@ -749,14 +750,14 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog )
+		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog )
 		{
 			try
 			{
 				var result = 0;
 				await ActionPolicies.GetAsync.Do( async () =>
 				{
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					var res0 = await this._magentoSoapService.catalogCategoryAttributeCurrentStoreAsync( sessionId.SessionId, storeId ).ConfigureAwait( false );
 
 					var catalogProductCreateEntity = new catalogProductCreateEntity
@@ -787,11 +788,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 				var res = await this._magentoSoapService.catalogCategoryRemoveProductAsync( sessionId.SessionId, categoryId, productId, identiferType ).ConfigureAwait( false );
 
 				//product id
@@ -820,7 +821,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
+		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, CancellationToken cancellationToken, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
 		{
 			try
 			{
@@ -830,7 +831,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 				await ActionPolicies.GetAsync.Do( async () =>
 				{
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					var temp = await ClientBaseActionRunner.RunWithAbortAsync(
 						abortAfter,

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
@@ -75,6 +75,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			return MagentoVersions.M_1_9_0_1;
 		}
 
+		public DateTime? LastActivityTime
+		{
+			get { return null; }
+		}
+
 		private void LogTraceGetResponseException( Exception exception )
 		{
 			MagentoLogger.Log().Trace( exception, "[magento] SOAP throw an exception." );

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Factory.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Factory.cs
@@ -1,10 +1,11 @@
 ﻿using MagentoAccess.Models.Credentials;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 {
 	internal class MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory: IMagentoServiceLowLevelSoapFactory
 	{
-		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config )
+		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			return new MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE(
 				credentials.SoapApiUser,

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
@@ -13,7 +13,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 {
 	internal partial class MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE : IMagentoServiceLowLevelSoap
 	{
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -44,7 +44,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderListAsync( sessionId.SessionId, filters ).ConfigureAwait( false );
@@ -61,7 +61,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -93,7 +93,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderListAsync( sessionId.SessionId, filters ).ConfigureAwait( false );
@@ -107,7 +107,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 		{
 			try
 			{
@@ -124,7 +124,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderInfoAsync( sessionId.SessionId, incrementId ).ConfigureAwait( false );
@@ -138,9 +138,9 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark )
+		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
-			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, childMark );
+			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
@@ -8,6 +8,7 @@ using MagentoAccess.MagentoSoapServiceReference;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Soap.GetOrders;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 {
@@ -61,7 +62,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField = "increment_id" )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -77,7 +78,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					filters.complex_filter[ 1 ] = new complexFilter { key = "store_id", value = new associativeEntity { key = "in", value = this.Store } };
 				}
 
-				filters.complex_filter[ 0 ] = new complexFilter { key = "increment_id", value = new associativeEntity { key = "in", value = ordersIdsAgregated } };
+				filters.complex_filter[ 0 ] = new complexFilter { key = searchField, value = new associativeEntity { key = "in", value = ordersIdsAgregated } };
 
 				const int maxCheckCount = 2;
 				const int delayBeforeCheck = 1800000;
@@ -141,6 +142,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
 			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
+		}
+
+		public Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
+		{
+			return Task.FromResult( new Dictionary< string, IEnumerable< Shipment > >() );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Products.cs
@@ -13,7 +13,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 {
 	internal partial class MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE : IMagentoServiceLowLevelSoap, IMagentoServiceLowLevelSoapGetProductsBySku, IMagentoServiceLowLevelSoapFillProductsDetails
 	{
-		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null )
+		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -21,7 +21,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 				{
 					var sourceList = Enumerable.Range( start1, count1 ).Select( selector1 ).ToList();
 
-					var productsResponses = await sourceList.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsAsync( productType, productTypeShouldBeExcluded, x, updatedFrom ).ConfigureAwait( false ) ).ConfigureAwait( false );
+					var productsResponses = await sourceList.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsAsync( productType, productTypeShouldBeExcluded, x, updatedFrom, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
 					var prods = productsResponses.SelectMany( x => x.Products ).ToList();
 					return prods;
 				};
@@ -38,13 +38,13 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, IReadOnlyCollection< string > skus, Mark mark = null )
+		public virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, IReadOnlyCollection< string > skus, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
 				var skusList = skus.ToList();
 				var skusListChunks = skusList.SplitToChunks( 10 );
-				var responses = await skusListChunks.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsPageAsync( productType, productTypeShouldBeExcluded, x, updatedFrom ).ConfigureAwait( false ) ).ConfigureAwait( false );
+				var responses = await skusListChunks.ProcessInBatchAsync( this._getProductsMaxThreads, async x => await this.GetProductsPageAsync( productType, productTypeShouldBeExcluded, x, updatedFrom, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
 				var soapGetProductsResponse = new SoapGetProductsResponse { Products = responses.SelectMany( x => x.Products ) };
 				return soapGetProductsResponse;
 			}
@@ -54,7 +54,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		protected virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, string productIdLike, DateTime? updatedFrom )
+		protected virtual async Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, string productIdLike, DateTime? updatedFrom, CancellationToken cancellationToken )
 		{
 			try
 			{
@@ -81,7 +81,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.catalogProductListAsync( sessionId.SessionId, filters, store ).ConfigureAwait( false );
@@ -95,7 +95,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 		}
 
-		protected virtual async Task< SoapGetProductsResponse > GetProductsPageAsync( string productType, bool productTypeShouldBeExcluded, IEnumerable< string > skus, DateTime? updatedFrom )
+		protected virtual async Task< SoapGetProductsResponse > GetProductsPageAsync( string productType, bool productTypeShouldBeExcluded, IEnumerable< string > skus, DateTime? updatedFrom, CancellationToken cancellationToken )
 		{
 			var inCondition = string.Join( ",", ( skus ?? Enumerable.Empty< string >() ) );
 			var filters = new filters { filter = new associativeEntity[ 0 ], complex_filter = new complexFilter[ 0 ] };
@@ -111,10 +111,10 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 
 			return await this.GetWithAsync(
 				res => new SoapGetProductsResponse( res ),
-				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
+				async ( client, session ) => await client.catalogProductListAsync( session, filters, store ).ConfigureAwait( false ), 600000, cancellationToken ).ConfigureAwait( false );
 		}
 
-		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
+		public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
@@ -89,7 +89,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+		public async Task< GetSessionIdResponse > GetSessionId( CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -173,7 +173,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			filters.complex_filter = temp.ToArray();
 		}
 
-		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( string rootCategory = "1" )
+		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( CancellationToken cancellationToken, string rootCategory = "1" )
 		{
 			try
 			{
@@ -189,7 +189,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -205,7 +205,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, bool throwException = true )
+		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -221,7 +221,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -237,7 +237,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute )
+		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute, CancellationToken cancellationToken )
 		{
 			try
 			{
@@ -253,7 +253,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					try // this try catch block is crunch for 1.7
 					{
 						using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
@@ -279,17 +279,17 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts )
+		public async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts, CancellationToken cancellationToken )
 		{
 			return await this.Magento1xxxHelper.FillProductDetails( resultProducts ).ConfigureAwait( false );
 		}
 
-		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new NotImplementedException();
 		}
 
-		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, bool throwException = true )
+		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -305,7 +305,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					var attributes = new catalogProductRequestAttributes { additional_attributes = request.custAttributes ?? new string[ 0 ] };
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
@@ -322,7 +322,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -340,7 +340,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -357,7 +357,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark = null )
+		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark = null )
 		{
 			var methodParameters = stockItems.ToJson();
 			try
@@ -380,7 +380,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -404,7 +404,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, Mark markForLog )
+		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, CancellationToken cancellationToken, Mark markForLog )
 		{
 			try
 			{
@@ -424,7 +424,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 					{
@@ -448,7 +448,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -464,7 +464,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.magentoInfoAsync( sessionId.SessionId ).ConfigureAwait( false );
@@ -481,11 +481,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 		}
 
 		#region JustForTesting
-		public async Task< int > CreateCart( string storeid )
+		public async Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartCreateAsync( sessionId.SessionId, storeid ).ConfigureAwait( false );
 
@@ -497,11 +497,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< string > CreateOrder( int shoppingcartid, string store )
+		public async Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartOrderAsync( sessionId.SessionId, shoppingcartid, store, null ).ConfigureAwait( false );
 
@@ -514,6 +514,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 		}
 
 		public async Task< int > CreateCustomer(
+			CancellationToken cancellationToken,
 			string email = "na@na.com",
 			string firstname = "firstname",
 			string lastname = "lastname",
@@ -525,7 +526,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerCustomerEntityToCreate = new customerCustomerEntityToCreate
 				{
@@ -547,11 +548,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store )
+		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cutomers = await this._magentoSoapService.customerCustomerListAsync( sessionId.SessionId, new filters() ).ConfigureAwait( false );
 
@@ -584,11 +585,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customer = new shoppingCartCustomerEntity
 				{
@@ -610,11 +611,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerAddressEntities = new shoppingCartCustomerAddressEntity[ 2 ];
 
@@ -661,11 +662,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > DeleteCustomer( int customerId )
+		public async Task< bool > DeleteCustomer( int customerId, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.customerCustomerDeleteAsync( sessionId.SessionId, customerId ).ConfigureAwait( false );
 
@@ -677,11 +678,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var shoppingCartProductEntities = new shoppingCartProductEntity[ 1 ];
 
@@ -697,11 +698,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cartPaymentMethodEntity = new shoppingCartPaymentMethodEntity
 				{
@@ -727,11 +728,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartShippingListAsync( sessionId.SessionId, shoppingCartId, store ).ConfigureAwait( false );
 
@@ -748,14 +749,14 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog )
+		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog )
 		{
 			try
 			{
 				var result = 0;
 				await ActionPolicies.GetAsync.Do( async () =>
 				{
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					var res0 = await this._magentoSoapService.catalogCategoryAttributeCurrentStoreAsync( sessionId.SessionId, storeId ).ConfigureAwait( false );
 
 					var catalogProductCreateEntity = new catalogProductCreateEntity
@@ -786,11 +787,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 				var res = await this._magentoSoapService.catalogCategoryRemoveProductAsync( sessionId.SessionId, categoryId, productId, identiferType ).ConfigureAwait( false );
 
 				//product id
@@ -819,7 +820,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
+		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, CancellationToken cancellationToken, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
 		{
 			try
 			{
@@ -829,7 +830,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 				await ActionPolicies.GetAsync.Do( async () =>
 				{
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					var temp = await ClientBaseActionRunner.RunWithAbortAsync(
 						abortAfter,

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE.cs
@@ -70,6 +70,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			return MagentoVersions.ZS_1_7_0_1;
 		}
 
+		public DateTime? LastActivityTime
+		{
+			get { return null; }
+		}
+
 		private void LogTraceGetResponseException( Exception exception )
 		{
 			MagentoLogger.Log().Trace( exception, "[magento] SOAP throw an exception." );

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Factory.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Factory.cs
@@ -1,10 +1,11 @@
 ﻿using MagentoAccess.Models.Credentials;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 {
 	internal class ZoeyServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory : IMagentoServiceLowLevelSoapFactory
 	{
-		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config )
+		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			return new ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE(
 				credentials.SoapApiUser,

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
@@ -7,6 +7,7 @@ using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Soap.GetOrders;
 using MagentoAccess.TsZoey_v_1_9_0_1_CE;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 {
@@ -59,7 +60,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField = "increment_id" )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -75,7 +76,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					filters.complex_filter[ 1 ] = new complexFilter { key = "store_id", value = new associativeEntity { key = "in", value = this.Store } };
 				}
 
-				filters.complex_filter[ 0 ] = new complexFilter { key = "increment_id", value = new associativeEntity { key = "in", value = ordersIdsAgregated } };
+				filters.complex_filter[ 0 ] = new complexFilter { key = searchField, value = new associativeEntity { key = "in", value = ordersIdsAgregated } };
 
 				const int maxCheckCount = 2;
 				const int delayBeforeCheck = 1800000;
@@ -138,6 +139,11 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
 			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
+		}
+
+		public Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
+		{
+			return Task.FromResult( new Dictionary< string, IEnumerable< Shipment > >() );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_7_0_1_ce_1_9_0_1_ce_Zoey/ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Orders.cs
@@ -12,7 +12,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 {
 	internal partial class ZoeyServiceLowLevelSoap_v_from_1_7_to_1_9_CE : IMagentoServiceLowLevelSoap
 	{
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -42,7 +42,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderListAsync( sessionId.SessionId, filters ).ConfigureAwait( false );
@@ -59,7 +59,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -90,7 +90,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderListAsync( sessionId.SessionId, filters ).ConfigureAwait( false );
@@ -104,7 +104,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 		{
 			try
 			{
@@ -121,7 +121,7 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 					TimerCallback tcb = statusChecker.CheckStatus;
 
 					privateClient = this._clientFactory.RefreshClient( privateClient );
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 					using( var stateTimer = new Timer( tcb, privateClient, 1000, delayBeforeCheck ) )
 						res = await privateClient.salesOrderInfoAsync( sessionId.SessionId, incrementId ).ConfigureAwait( false );
@@ -135,9 +135,9 @@ namespace MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce_Zoey
 			}
 		}
 
-		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark )
+		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
-			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, childMark );
+			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE.cs
+++ b/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE.cs
@@ -117,6 +117,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			return MagentoVersions.M_1_9_2_0;
 		}
 
+		public DateTime? LastActivityTime
+		{
+			get { return null; }
+		}
+
 		public Task< bool > InitAsync( bool supressExceptions = false )
 		{
 			try

--- a/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE.cs
+++ b/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE.cs
@@ -131,7 +131,7 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+		public async Task< GetSessionIdResponse > GetSessionId( CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -175,57 +175,57 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			filters.complex_filter = temp.ToArray();
 		}
 
-		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public virtual async Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.GetWithAsync(
 				x => new InventoryStockItemListResponse( x ),
-				async ( client, session ) => await client.catalogInventoryStockItemListAsync( session, skusOrIds.ToArray() ).ConfigureAwait( false ), 60000 ).ConfigureAwait( false );
+				async ( client, session ) => await client.catalogInventoryStockItemListAsync( session, skusOrIds.ToArray() ).ConfigureAwait( false ), 60000, cancellationToken ).ConfigureAwait( false );
 		}
 		
-		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest request, bool throwException = true )
+		public virtual async Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest request, CancellationToken cancellationToken, bool throwException = true )
 		{
 			return await this.GetWithAsync(
 				x => new ProductAttributeMediaListResponse( x, request.ProductId, request.Sku ),
-				async ( client, session ) => await client.catalogProductAttributeMediaListAsync( session, request.ProductId, "0", "1" ).ConfigureAwait( false ), 25000 ).ConfigureAwait(false);
+				async ( client, session ) => await client.catalogProductAttributeMediaListAsync( session, request.ProductId, "0", "1" ).ConfigureAwait( false ), 25000, cancellationToken ).ConfigureAwait(false);
 		}
 
-		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( string rootCategory = "1" )
+		public virtual async Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( CancellationToken cancellationToken, string rootCategory = "1" )
 		{
 			return await this.GetWithAsync(
 				x => new GetCategoryTreeResponse( x ),
-				async ( client, session ) => await client.catalogCategoryTreeAsync( session, rootCategory, "0" ).ConfigureAwait( false ), 25000 ).ConfigureAwait(false);
+				async ( client, session ) => await client.catalogCategoryTreeAsync( session, rootCategory, "0" ).ConfigureAwait( false ), 25000, cancellationToken ).ConfigureAwait(false);
 		}
 
-		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, bool throwException = true )
+		public virtual async Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest request, CancellationToken cancellationToken, bool throwException = true )
 		{
 			var attributes = new catalogProductRequestAttributes { additional_attributes = request.custAttributes ?? new string[ 0 ] };
 			return await this.GetWithAsync(
 				x => new CatalogProductInfoResponse( x ),
-				async ( client, session ) => await client.catalogProductInfoAsync( session, request.ProductId, "0", attributes, "1" ).ConfigureAwait( false ), 25000 ).ConfigureAwait(false);
+				async ( client, session ) => await client.catalogProductInfoAsync( session, request.ProductId, "0", attributes, "1" ).ConfigureAwait( false ), 25000, cancellationToken ).ConfigureAwait(false);
 		}
 
-		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute )
+		public virtual async Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute, CancellationToken cancellationToken )
 		{
 			return await this.GetWithAsync(
 				x => new CatalogProductAttributeInfoResponse( x ),
-				async ( client, session ) => await client.catalogProductAttributeInfoAsync( session, attribute ).ConfigureAwait( false ), 25000 ).ConfigureAwait(false);
+				async ( client, session ) => await client.catalogProductAttributeInfoAsync( session, attribute ).ConfigureAwait( false ), 25000, cancellationToken ).ConfigureAwait(false);
 		}
 
-		public virtual async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts )
+		public virtual async Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts, CancellationToken cancellationToken )
 		{
 			return await this.Magento1xxxHelper.FillProductDetails( resultProducts ).ConfigureAwait( false );
 		}
 
-		public async Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public async Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			var pages = new PagingModel( 1000, 0 ).GetPages( skusOrIds ).ToList();
 
-			var pagesResult = await pages.ProcessInBatchAsync( 4, async x => await this.GetStockItemsAsync( x, scopes ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var pagesResult = await pages.ProcessInBatchAsync( 4, async x => await this.GetStockItemsAsync( x, scopes, cancellationToken ).ConfigureAwait( false ) ).ConfigureAwait( false );
 			var result = new InventoryStockItemListResponse( pagesResult.SelectMany( x => x.InventoryStockItems ).ToList() );
 			return result;
 		}
 
-		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark = null )
+		public virtual async Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark = null )
 		{
 			var methodParameters = stockItems.ToJson();
 			var stockItemsProcessed = stockItems.Select( x =>
@@ -239,14 +239,15 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			var stockItemsAsync = await this.GetWithSafeAsync(
 				res => ( object )res.result,
 				async ( client, session ) => await client.catalogInventoryStockItemMultiUpdateAsync( session, stockItemsProcessed.Select( x => x.Item1.ProductId ).ToArray(), stockItemsProcessed.Select( x => x.Item2 ).ToArray() ).ConfigureAwait( false ),
-				600000 ).ConfigureAwait( false );
+				600000,
+				cancellationToken ).ConfigureAwait( false );
 
 			var results = stockItems.Select( x => new RpcInvoker.RpcRequestResponse< PutStockItem, object >( x, stockItemsAsync ) );
 
 			return results;
 		}
 
-		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, Mark markForLog )
+		public virtual async Task< bool > PutStockItemAsync( PutStockItem putStockItem, CancellationToken cancellationToken, Mark markForLog )
 		{
 			var catalogInventoryStockItemUpdateEntity = putStockItem.Qty > 0 ?
 				new catalogInventoryStockItemUpdateEntity() { is_in_stock = 1, is_in_stockSpecified = true, qty = putStockItem.Qty.ToString() } :
@@ -254,14 +255,14 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 
 			return await this.GetWithAsync(
 				res => res.result > 0,
-				async ( client, session ) => await client.catalogInventoryStockItemUpdateAsync( session, putStockItem.ProductId, catalogInventoryStockItemUpdateEntity ).ConfigureAwait( false ), 600000 ).ConfigureAwait(false);
+				async ( client, session ) => await client.catalogInventoryStockItemUpdateAsync( session, putStockItem.ProductId, catalogInventoryStockItemUpdateEntity ).ConfigureAwait( false ), 600000, cancellationToken ).ConfigureAwait(false);
 		}
 		
-		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return await this.GetWithAsync(
 				res => new GetMagentoInfoResponse( res, this.GetServiceVersion() ),
-				async ( client, session ) => await client.magentoInfoAsync( session ).ConfigureAwait( false ), 600000, suppressException ).ConfigureAwait(false);
+				async ( client, session ) => await client.magentoInfoAsync( session ).ConfigureAwait( false ), 600000, cancellationToken, suppressException ).ConfigureAwait(false);
 		}
 
 		protected void LogTraceGetResponseException( Exception exception )
@@ -270,11 +271,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 		}
 
 		#region JustForTesting
-		public async Task< int > CreateCart( string storeid )
+		public async Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartCreateAsync( sessionId.SessionId, storeid ).ConfigureAwait( false );
 
@@ -286,11 +287,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< string > CreateOrder( int shoppingcartid, string store )
+		public async Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartOrderAsync( sessionId.SessionId, shoppingcartid, store, null ).ConfigureAwait( false );
 
@@ -303,6 +304,7 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 		}
 
 		public async Task< int > CreateCustomer(
+			CancellationToken cancellationToken,
 			string email = "na@na.com",
 			string firstname = "firstname",
 			string lastname = "lastname",
@@ -314,7 +316,7 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerCustomerEntityToCreate = new customerCustomerEntityToCreate
 				{
@@ -336,11 +338,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store )
+		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cutomers = await this._magentoSoapService.customerCustomerListAsync( sessionId.SessionId, new filters() ).ConfigureAwait( false );
 
@@ -373,11 +375,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customer = new shoppingCartCustomerEntity
 				{
@@ -399,11 +401,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var customerAddressEntities = new shoppingCartCustomerAddressEntity[ 2 ];
 
@@ -450,11 +452,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > DeleteCustomer( int customerId )
+		public async Task< bool > DeleteCustomer( int customerId, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.customerCustomerDeleteAsync( sessionId.SessionId, customerId ).ConfigureAwait( false );
 
@@ -466,11 +468,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var shoppingCartProductEntities = new shoppingCartProductEntity[ 1 ];
 
@@ -486,11 +488,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var cartPaymentMethodEntity = new shoppingCartPaymentMethodEntity
 				{
@@ -516,11 +518,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var res = await this._magentoSoapService.shoppingCartShippingListAsync( sessionId.SessionId, shoppingCartId, store ).ConfigureAwait( false );
 
@@ -537,14 +539,14 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog )
+		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog )
 		{
 			try
 			{
 				var result = 0;
 				await ActionPolicies.GetAsync.Do( async () =>
 				{
-					var sessionId = await this.GetSessionId().ConfigureAwait( false );
+					var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 					var res0 = await this._magentoSoapService.catalogCategoryAttributeCurrentStoreAsync( sessionId.SessionId, storeId ).ConfigureAwait( false );
 					var catalogProductCreateEntity = new catalogProductCreateEntity
 					{
@@ -573,11 +575,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 		{
 			try
 			{
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 				var res = await this._magentoSoapService.catalogCategoryRemoveProductAsync( sessionId.SessionId, categoryId, productId, identiferType ).ConfigureAwait( false );
 
 				//product id
@@ -606,11 +608,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
+		private async Task< TResult > GetWithAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, CancellationToken cancellationToken, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new()
 		{
 			try
 			{
-				return await this.GetWithUnsafeAsync( converter, action, abortAfter ).ConfigureAwait( false );
+				return await this.GetWithUnsafeAsync( converter, action, abortAfter, cancellationToken ).ConfigureAwait( false );
 			}
 			catch( Exception exc )
 			{
@@ -620,15 +622,15 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			}
 		}
 
-		private async Task< RpcInvoker.RpcResponse< TResult > > GetWithSafeAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new() where TResult : class
+		private async Task< RpcInvoker.RpcResponse< TResult > > GetWithSafeAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, CancellationToken cancellationToken, bool suppressException = false, [ CallerMemberName ] string callerName = null ) where TServerResponse : new() where TResult : class
 		{
 			var withSafeAsync = await RpcInvoker.SuppressExceptions(
-				async () => await this.GetWithUnsafeAsync( converter, action, abortAfter ).ConfigureAwait( false )
+				async () => await this.GetWithUnsafeAsync( converter, action, abortAfter, cancellationToken ).ConfigureAwait( false )
 				).ConfigureAwait( false );
 			return withSafeAsync;
 		}
 
-		private async Task< TResult > GetWithUnsafeAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter ) where TServerResponse : new()
+		private async Task< TResult > GetWithUnsafeAsync< TResult, TServerResponse >( Func< TServerResponse, TResult > converter, Func< Mage_Api_Model_Server_Wsi_HandlerPortTypeClient, string, Task< TServerResponse > > action, int abortAfter, CancellationToken cancellationToken ) where TServerResponse : new()
 		{
 			var res = new TServerResponse();
 			var privateClient = this._clientFactory.GetClient();
@@ -636,7 +638,7 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 			await ActionPolicies.GetAsync.Do( async () =>
 			{
 				privateClient = this._clientFactory.RefreshClient( privateClient );
-				var sessionId = await this.GetSessionId().ConfigureAwait( false );
+				var sessionId = await this.GetSessionId( cancellationToken ).ConfigureAwait( false );
 
 				var temp = await ClientBaseActionRunner.RunWithAbortAsync(
 					abortAfter,

--- a/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Orders.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.MagentoSoapServiceReference;
 using MagentoAccess.Misc;
@@ -11,7 +12,7 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 {
 	internal partial class MagentoServiceLowLevelSoap_v_1_9_2_1_ce : IMagentoServiceLowLevelSoap
 	{
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			var filters = new filters();
 			AddFilter( filters, modifiedFrom.ToSoapParameterString(), "updated_at", "from" );
@@ -26,10 +27,10 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 					res.result = res.result.Where( x => Extensions.ToDateTimeOrDefault( x.updated_at ) >= modifiedFrom && Extensions.ToDateTimeOrDefault( x.updated_at ) <= modifiedTo ).ToArray();
 					return new GetOrdersResponse( res );
 				},
-				async ( client, session ) => await client.salesOrderListAsync( session, filters ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
+				async ( client, session ) => await client.salesOrderListAsync( session, filters ).ConfigureAwait( false ), 600000, cancellationToken ).ConfigureAwait( false );
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			var ordersIdsAgregated = string.Join( ",", ordersIds );
 
@@ -41,19 +42,19 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 
 			return await this.GetWithAsync(
 				res => new GetOrdersResponse( res ),
-				async ( client, session ) => await client.salesOrderListAsync( session, filters ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
+				async ( client, session ) => await client.salesOrderListAsync( session, filters ).ConfigureAwait( false ), 600000, cancellationToken ).ConfigureAwait( false );
 		}
 
-		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 		{
 			return await this.GetWithAsync(
 				res => new OrderInfoResponse( res ),
-				async ( client, session ) => await client.salesOrderInfoAsync( session, incrementId ).ConfigureAwait( false ), 600000 ).ConfigureAwait( false );
+				async ( client, session ) => await client.salesOrderInfoAsync( session, incrementId ).ConfigureAwait( false ), 600000, cancellationToken ).ConfigureAwait( false );
 		}
 
-		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark )
+		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
-			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, childMark );
+			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_CE_Orders.cs
@@ -7,6 +7,7 @@ using MagentoAccess.MagentoSoapServiceReference;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Soap.GetOrders;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 {
@@ -30,12 +31,12 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 				async ( client, session ) => await client.salesOrderListAsync( session, filters ).ConfigureAwait( false ), 600000, cancellationToken ).ConfigureAwait( false );
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField = "increment_id" )
 		{
 			var ordersIdsAgregated = string.Join( ",", ordersIds );
 
 			var filters = new filters();
-			AddFilter( filters, ordersIdsAgregated, "increment_id", "in" );
+			AddFilter( filters, ordersIdsAgregated, searchField, "in" );
 
 			if( !string.IsNullOrWhiteSpace( this.Store ) )
 				AddFilter( filters, this.Store, "store_id", "in" );
@@ -55,6 +56,11 @@ namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
 			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
+		}
+
+		public Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
+		{
+			return Task.FromResult( new Dictionary< string, IEnumerable< Shipment > >() );
 		}
 	}
 }

--- a/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Factory.cs
+++ b/src/MagentoAccess/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Factory.cs
@@ -1,11 +1,12 @@
 ﻿using MagentoAccess.Models.Credentials;
 using MagentoAccess.Services.Soap._1_9_2_1_ce;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Soap._1_9_2_1_ce
 {
 	internal class MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Factory : IMagentoServiceLowLevelSoapFactory
 	{
-		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config )
+		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			return new MagentoServiceLowLevelSoap_v_1_9_2_1_ce(
 				credentials.SoapApiUser,

--- a/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Factory.cs
+++ b/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Factory.cs
@@ -1,10 +1,11 @@
 ﻿using MagentoAccess.Models.Credentials;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 {
 	internal class MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Factory : IMagentoServiceLowLevelSoapFactory
 	{
-		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config )
+		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			return new MagentoServiceLowLevelSoap_v_2_0_2_0_ce(
 				credentials.SoapApiUser,

--- a/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Misc.cs
+++ b/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Misc.cs
@@ -56,6 +56,11 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return MagentoVersions.M_2_0_2_0;
 		}
 
+		public DateTime? LastActivityTime
+		{
+			get { return null; }
+		}
+
 		private void LogTraceGetResponseException( Exception exception )
 		{
 			MagentoLogger.Log().Trace( exception, "[magento] SOAP throw an exception." );

--- a/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Misc.cs
+++ b/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Misc.cs
@@ -129,21 +129,21 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return $"{{BaseMagentoUrl:{( string.IsNullOrWhiteSpace( this.BaseMagentoUrl ) ? PredefinedValues.NotAvailable : this.BaseMagentoUrl )}, ApiUser:{( string.IsNullOrWhiteSpace( this.ApiUser ) ? PredefinedValues.NotAvailable : this.ApiUser )},ApiKey:{( string.IsNullOrWhiteSpace( this.ApiKey ) ? PredefinedValues.NotAvailable : this.ApiKey )},ApiToken:{( string.IsNullOrWhiteSpace( this._sessionId ) ? PredefinedValues.NotAvailable : this._sessionId )},Store:{( string.IsNullOrWhiteSpace( this.Store ) ? PredefinedValues.NotAvailable : this.Store )}}}";
 		}
 
-		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
 				// Magento doesn't provide method to receive magento vesrion, since Magento2.0 thats why we use backEndMoodules API
 				
-				var sessionIdRespnse = await this.GetSessionId( !suppressException ).ConfigureAwait( false );
+				var sessionIdRespnse = await this.GetSessionId( cancellationToken, !suppressException ).ConfigureAwait( false );
 				if( sessionIdRespnse == null )
 				{
 					MagentoLogger.LogTrace( "Can't get session id. Possible reasons: incorrect credentials, user was blocked." );
 					return null;
 				}
 				//var modules = await this.GetBackEndModulesAsync().ConfigureAwait( false );
-				var getOrdersResponse = await this.GetOrdersAsync( DateTime.Now, DateTime.Now.AddHours( 1 ), mark ).ConfigureAwait( false );
-				var getProductsRes = await this.GetProductsAsync( 1, null, false, null, mark ).ConfigureAwait( false );
+				var getOrdersResponse = await this.GetOrdersAsync( DateTime.Now, DateTime.Now.AddHours( 1 ), cancellationToken, mark ).ConfigureAwait( false );
+				var getProductsRes = await this.GetProductsAsync( 1, null, false, null, cancellationToken, mark ).ConfigureAwait( false );
 
 				//var saveMethodResult = await this.SaveOrderMethodExistAsync().ConfigureAwait( false );
 				return /*modules?.Modules != null && modules.Modules.Count > 0 &&*/ getOrdersResponse.Orders.Count() >= 0 && getProductsRes.Products.Count() >= 0 ? new GetMagentoInfoResponse( "2.0.2.0", "CE", this.GetServiceVersion() ) : null;
@@ -156,7 +156,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public async Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+		public async Task< GetSessionIdResponse > GetSessionId( CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -190,7 +190,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 		#endregion
 
 		#region JustForTesting
-		public async Task< int > CreateCart( string storeid )
+		public async Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -207,7 +207,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( 0 ).ConfigureAwait( false );
 		}
 
-		public async Task< string > CreateOrder( int shoppingcartid, string store )
+		public async Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -225,6 +225,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 		}
 
 		public async Task< int > CreateCustomer(
+			CancellationToken cancellationToken,
 			string email = "na@na.com",
 			string firstname = "firstname",
 			string lastname = "lastname",
@@ -259,7 +260,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( 0 ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store )
+		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -297,7 +298,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -324,7 +325,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -376,7 +377,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > DeleteCustomer( int customerId )
+		public async Task< bool > DeleteCustomer( int customerId, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -393,7 +394,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -414,7 +415,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -445,7 +446,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -483,7 +484,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog )
+		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog )
 		{
 			var stockItem = new CreatteProductModel( name, sku, isInStock, productType );
 			var methodParameters = stockItem.ToJson();
@@ -555,7 +556,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 		{
 			//try
 			//{

--- a/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Orders.cs
@@ -14,7 +14,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 	{
 		private const int PageSize = 100;
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -45,7 +45,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -77,7 +77,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 		{
 			try
 			{
@@ -119,9 +119,9 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark )
+		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
-			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, childMark );
+			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
 		}
 
 		#region Pagination

--- a/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Orders.cs
@@ -7,6 +7,7 @@ using MagentoAccess.Magento2salesOrderRepositoryV1_v_2_0_2_0_CE;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Soap.GetOrders;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 {
@@ -45,7 +46,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken,  string searchField = "increment_id" )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -53,7 +54,7 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 				ordersIdsAgregated = string.Join( ",", ordersIds );
 				var frameworkSearchFilterGroups = new List< FrameworkSearchFilterGroup >
 				{
-					new FrameworkSearchFilterGroup() { filters = new[] { new FrameworkFilter() { field = "increment_id", conditionType = "eq", value = ordersIdsAgregated } } },
+					new FrameworkSearchFilterGroup() { filters = new[] { new FrameworkFilter() { field = searchField, conditionType = "eq", value = ordersIdsAgregated } } },
 				};
 				if( string.IsNullOrWhiteSpace( this.Store ) )
 					frameworkSearchFilterGroups.Add( new FrameworkSearchFilterGroup() { filters = new[] { new FrameworkFilter() { field = "store_Id", conditionType = "eq", value = this.Store } } } );
@@ -122,6 +123,11 @@ namespace MagentoAccess.Services.Soap._2_0_2_0_ce
 		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 		{
 			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, childMark );
+		}
+
+		public Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
+		{
+			return Task.FromResult( new Dictionary< string, IEnumerable< Shipment > >() );
 		}
 
 		#region Pagination

--- a/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory.cs
+++ b/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory.cs
@@ -1,10 +1,11 @@
 ﻿using MagentoAccess.Models.Credentials;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 {
 	internal class MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Factory : IMagentoServiceLowLevelSoapFactory
 	{
-		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config )
+		public IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			return new MagentoServiceLowLevelSoap_v_2_1_0_0_ce(
 				credentials.SoapApiUser,

--- a/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Misc.cs
+++ b/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Misc.cs
@@ -77,7 +77,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public async Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+		public async Task< GetSessionIdResponse > GetSessionId( CancellationToken cancellationToken, bool throwException = true )
 		{
 			try
 			{
@@ -139,21 +139,21 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			this.getSessionIdSemaphore = new SemaphoreSlim( 1, 1 );
 		}
 
-		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public virtual async Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
 				// Magento doesn't provide method to receive magento vesrion, since Magento2.0 thats why we use backEndMoodules API
 
-				var sessionIdRespnse = await this.GetSessionId( !suppressException ).ConfigureAwait( false );
+				var sessionIdRespnse = await this.GetSessionId( cancellationToken, !suppressException ).ConfigureAwait( false );
 				if( sessionIdRespnse == null )
 				{
 					MagentoLogger.LogTrace( "Can't get session id. Possible reasons: incorrect credentials, user was blocked." );
 					return null;
 				}
 				//var modules = await this.GetBackEndModulesAsync().ConfigureAwait( false );
-				var getOrdersResponse = await this.GetOrdersAsync( DateTime.Now, DateTime.Now.AddHours( 1 ) ).ConfigureAwait( false );
-				var getProductsRes = await this.GetProductsAsync( 1, null, false, null ).ConfigureAwait( false );
+				var getOrdersResponse = await this.GetOrdersAsync( DateTime.Now, DateTime.Now.AddHours( 1 ), cancellationToken ).ConfigureAwait( false );
+				var getProductsRes = await this.GetProductsAsync( 1, null, false, null, cancellationToken ).ConfigureAwait( false );
 
 				//var saveMethodResult = await this.SaveOrderMethodExistAsync().ConfigureAwait( false );
 				return /*modules?.Modules != null && modules.Modules.Count > 0 &&*/ getOrdersResponse.Orders.Count() >= 0 && getProductsRes.Products.Count() >= 0 ? new GetMagentoInfoResponse( "2.1.0.0", "CE", this.GetServiceVersion() ) : null;
@@ -190,7 +190,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 		}
 
 		#region JustForTesting
-		public async Task< int > CreateCart( string storeid )
+		public async Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -207,7 +207,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( 0 ).ConfigureAwait( false );
 		}
 
-		public async Task< string > CreateOrder( int shoppingcartid, string store )
+		public async Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -225,6 +225,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 		}
 
 		public async Task< int > CreateCustomer(
+			CancellationToken cancellationToken,
 			string email = "na@na.com",
 			string firstname = "firstname",
 			string lastname = "lastname",
@@ -259,7 +260,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( 0 ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store )
+		public async Task< bool > ShoppingCartCustomerSet( int shoppingCart, int customerId, string customerPass, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -297,7 +298,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+		public async Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -324,7 +325,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+		public async Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -376,7 +377,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > DeleteCustomer( int customerId )
+		public async Task< bool > DeleteCustomer( int customerId, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -393,7 +394,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+		public async Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -414,7 +415,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -445,7 +446,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return await Task.FromResult( false ).ConfigureAwait( false );
 		}
 
-		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+		public async Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 		{
 			//try
 			//{
@@ -483,7 +484,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog )
+		public async Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog )
 		{
 			var stockItem = new CreatteProductModel( name, sku, isInStock, productType );
 			var methodParameters = stockItem.ToJson();
@@ -557,7 +558,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+		public async Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 		{
 			//try
 			//{

--- a/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Misc.cs
+++ b/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Misc.cs
@@ -58,6 +58,11 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			return MagentoVersions.M_2_1_0_0;
 		}
 
+		public DateTime? LastActivityTime
+		{
+			get { return null; }
+		}
+
 		private void LogTraceGetResponseException( Exception exception )
 		{
 			MagentoLogger.Log().Trace( exception, "[magento] SOAP throw an exception." );

--- a/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Orders.cs
@@ -13,7 +13,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 	{
 		private const int PageSize = 100;
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -43,7 +43,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -75,7 +75,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark mark = null )
+		public virtual async Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark mark = null )
 		{
 			try
 			{
@@ -122,9 +122,9 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, Mark mark = null )
+		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark mark = null )
 		{
-			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, mark );
+			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, mark );
 		}
 
 		#region Pagination

--- a/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Orders.cs
+++ b/src/MagentoAccess/Services/Soap/2_1_0_0_ce/MagentoServiceLowLevelSoap_v_2_1_0_0_ce_Orders.cs
@@ -6,6 +6,7 @@ using MagentoAccess.Magento2salesOrderRepositoryV1_v_2_1_0_0_CE;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Services.Soap.GetOrders;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 {
@@ -43,7 +44,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 			}
 		}
 
-		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public virtual async Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField = "increment_id" )
 		{
 			var ordersIdsAgregated = string.Empty;
 			try
@@ -51,7 +52,7 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 				ordersIdsAgregated = string.Join( ",", ordersIds );
 				var frameworkSearchFilterGroups = new List< FrameworkSearchFilterGroup >
 				{
-					new FrameworkSearchFilterGroup() { filters = new[] { new FrameworkFilter() { field = "increment_id", conditionType = "eq", value = ordersIdsAgregated } } },
+					new FrameworkSearchFilterGroup() { filters = new[] { new FrameworkFilter() { field = searchField, conditionType = "eq", value = ordersIdsAgregated } } },
 				};
 				if( string.IsNullOrWhiteSpace( this.Store ) )
 					frameworkSearchFilterGroups.Add( new FrameworkSearchFilterGroup() { filters = new[] { new FrameworkFilter() { field = "store_Id", conditionType = "eq", value = this.Store } } } );
@@ -125,6 +126,11 @@ namespace MagentoAccess.Services.Soap._2_1_0_0_ce
 		public virtual Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark mark = null )
 		{
 			return this.GetOrderAsync( this.GetOrdersUsesEntityInsteadOfIncrementId ? order.OrderId : order.incrementId, cancellationToken, mark );
+		}
+
+		public Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
+		{
+			return Task.FromResult( new Dictionary< string, IEnumerable< Shipment > >() );
 		}
 
 		#region Pagination

--- a/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
+++ b/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.GetProducts;
@@ -27,27 +28,27 @@ namespace MagentoAccess.Services.Soap
 		bool GetStockItemsWithoutSkuImplementedWithPages { get; }
 		bool GetOrderByIdForFullInformation { get; }
 		bool GetOrdersUsesEntityInsteadOfIncrementId { get; }
-		Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null );
-		Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds );
-		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null );
-		Task< SoapGetProductsResponse > GetProductsBySkusAsync( IEnumerable< string > skus, Mark mark = null );
-		Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null );
-		Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark );
-		Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark );
-		Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark = null );
-		Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null );
+		Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null );
+		Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken );
+		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null );
+		Task< SoapGetProductsResponse > GetProductsBySkusAsync( IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark = null );
+		Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null );
+		Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark );
+		Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark );
+		Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark = null );
+		Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null );
 		string ToJsonSoapInfo();
-		Task< bool > PutStockItemAsync( PutStockItem putStockItem, Mark markForLog );
-		Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog = null );
-		Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType );
-		Task< int > CreateCart( string storeid );
-		Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store );
-		Task< bool > ShoppingCartAddressSet( int shoppingCart, string store );
-		Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store );
-		Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store );
-		Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store );
-		Task< string > CreateOrder( int shoppingcartid, string store );
-		Task< GetSessionIdResponse > GetSessionId( bool throwException = true );
+		Task< bool > PutStockItemAsync( PutStockItem putStockItem, CancellationToken cancellationToken, Mark markForLog );
+		Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog = null );
+		Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken token );
+		Task< int > CreateCart( string storeid, CancellationToken token );
+		Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken token );
+		Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken token );
+		Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken token );
+		Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken token );
+		Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken token );
+		Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken token );
+		Task< GetSessionIdResponse > GetSessionId( CancellationToken token, bool throwException = true );
 		string GetServiceVersion();
 
 		/// <summary>
@@ -56,22 +57,22 @@ namespace MagentoAccess.Services.Soap
 		/// <param name="catalogProductInfoRequest"></param>
 		/// <param name="throwException"></param>
 		/// <returns></returns>
-		Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest catalogProductInfoRequest, bool throwException = true );
+		Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest catalogProductInfoRequest, CancellationToken token, bool throwException = true );
 
-		Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, bool throwException = true );
-		Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( string rootCategory = "1" );
-		Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute );
-		Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null );
+		Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, CancellationToken token, bool throwException = true );
+		Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( CancellationToken token, string rootCategory = "1" );
+		Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute, CancellationToken token );
+		Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null );
 		Task< bool > InitAsync( bool supressExceptions = false );
 	}
 
 	internal interface IMagentoServiceLowLevelSoapGetProductsBySku
 	{
-		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, IReadOnlyCollection< string > skus, Mark mark = null );
+		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, IReadOnlyCollection< string > skus, CancellationToken cancellationToken, Mark mark = null );
 	}
 
 	internal interface IMagentoServiceLowLevelSoapFillProductsDetails
 	{
-		Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts );
+		Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts, CancellationToken cancellationToken );
 	}
 }

--- a/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
+++ b/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
@@ -16,6 +16,7 @@ using MagentoAccess.Models.Services.Soap.GetSessionId;
 using MagentoAccess.Models.Services.Soap.GetStockItems;
 using MagentoAccess.Models.Services.Soap.PutStockItems;
 using Netco.Logging;
+using MagentoAccess.Models.GetShipments;
 
 namespace MagentoAccess.Services.Soap
 {
@@ -34,7 +35,8 @@ namespace MagentoAccess.Services.Soap
 		DateTime? LastActivityTime { get; }
 
 		Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null );
-		Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken );
+		Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField = "increment_id" );
+		Task< Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null );
 		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null );
 		Task< SoapGetProductsResponse > GetProductsBySkusAsync( IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark = null );
 		Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null );

--- a/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
+++ b/src/MagentoAccess/Services/Soap/IMagentoServiceLowLevelSoap.cs
@@ -28,6 +28,11 @@ namespace MagentoAccess.Services.Soap
 		bool GetStockItemsWithoutSkuImplementedWithPages { get; }
 		bool GetOrderByIdForFullInformation { get; }
 		bool GetOrdersUsesEntityInsteadOfIncrementId { get; }
+		/// <summary>
+		///	This property can be used by the client to monitor the last access library's network activity time.
+		/// </summary>
+		DateTime? LastActivityTime { get; }
+
 		Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null );
 		Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken );
 		Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null );

--- a/src/MagentoAccess/Services/Soap/ImagentoServiceLowLevelSoapFactory.cs
+++ b/src/MagentoAccess/Services/Soap/ImagentoServiceLowLevelSoapFactory.cs
@@ -1,10 +1,11 @@
 ﻿using MagentoAccess.Models.Credentials;
 using MagentoAccess.Services.Soap._1_7_0_1_ce_1_9_0_1_ce;
+using MagentoAccess.Misc;
 
 namespace MagentoAccess.Services.Soap
 {
 	internal interface IMagentoServiceLowLevelSoapFactory
 	{
-		IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config );
+		IMagentoServiceLowLevelSoap CreateMagentoLowLevelService( MagentoAuthenticatedUserCredentials credentials, MagentoConfig config, MagentoTimeouts operationsTimeouts );
 	}
 }

--- a/src/MagentoAccess/Services/Soap/Magento1xxxHelper.cs
+++ b/src/MagentoAccess/Services/Soap/Magento1xxxHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.MagentoSoapServiceReference_v_1_14_1_EE;
 using MagentoAccess.Misc;
@@ -34,10 +35,10 @@ namespace MagentoAccess.Services.Soap
 			var resultProductslist = resultProducts as IList< ProductDetails > ?? resultProducts.ToList();
 			var attributes = new string[] { ProductAttributeCodes.Cost, ProductAttributeCodes.Manufacturer, ProductAttributeCodes.Upc };
 
-			var productsInfoTask = resultProductslist.ProcessInBatchAsync( 5, async x => await this._magentoServiceLowLevelSoap.GetProductInfoAsync( new CatalogProductInfoRequest( attributes, x.Sku, x.ProductId ) ).ConfigureAwait( false ) );
-			var productAttributesTask = this._magentoServiceLowLevelSoap.GetManufacturersInfoAsync( ProductAttributeCodes.Manufacturer );
-			var mediaListResponsesTask = resultProductslist.ProcessInBatchAsync( 5, async x => await this._magentoServiceLowLevelSoap.GetProductAttributeMediaListAsync( new GetProductAttributeMediaListRequest( x.ProductId, x.Sku ) ).ConfigureAwait( false ) );
-			var categoriesTreeResponseTask = this._magentoServiceLowLevelSoap.GetCategoriesTreeAsync();
+			var productsInfoTask = resultProductslist.ProcessInBatchAsync( 5, async x => await this._magentoServiceLowLevelSoap.GetProductInfoAsync( new CatalogProductInfoRequest( attributes, x.Sku, x.ProductId ), CancellationToken.None ).ConfigureAwait( false ) );
+			var productAttributesTask = this._magentoServiceLowLevelSoap.GetManufacturersInfoAsync( ProductAttributeCodes.Manufacturer, CancellationToken.None );
+			var mediaListResponsesTask = resultProductslist.ProcessInBatchAsync( 5, async x => await this._magentoServiceLowLevelSoap.GetProductAttributeMediaListAsync( new GetProductAttributeMediaListRequest( x.ProductId, x.Sku ), CancellationToken.None ).ConfigureAwait( false ) );
+			var categoriesTreeResponseTask = this._magentoServiceLowLevelSoap.GetCategoriesTreeAsync( CancellationToken.None );
 			await Task.WhenAll( productAttributesTask, productsInfoTask, mediaListResponsesTask, categoriesTreeResponseTask ).ConfigureAwait( false );
 
 			var productsInfo = productsInfoTask.Result;

--- a/src/MagentoAccess/Services/Soap/MagentoServiceLowLevelSoapParametrisedFactory.cs
+++ b/src/MagentoAccess/Services/Soap/MagentoServiceLowLevelSoapParametrisedFactory.cs
@@ -13,12 +13,14 @@ namespace MagentoAccess.Services.Soap
 		private readonly Dictionary< string, IMagentoServiceLowLevelSoap > _factories;
 		private readonly MagentoAuthenticatedUserCredentials _magentoAuthenticatedUserCredentials;
 		private readonly MagentoConfig _config;
+		private readonly MagentoTimeouts _operationsTimeouts;
 
-		public MagentoServiceLowLevelSoapFactory( MagentoAuthenticatedUserCredentials magentoAuthenticatedUserCredentials, Dictionary< string, IMagentoServiceLowLevelSoap > factories, MagentoConfig config )
+		public MagentoServiceLowLevelSoapFactory( MagentoAuthenticatedUserCredentials magentoAuthenticatedUserCredentials, Dictionary< string, IMagentoServiceLowLevelSoap > factories, MagentoConfig config, MagentoTimeouts operationsTimeouts )
 		{
 			this._magentoAuthenticatedUserCredentials = magentoAuthenticatedUserCredentials;
 			this._factories = factories;
 			this._config = config.DefaultIfNull();
+			this._operationsTimeouts = operationsTimeouts;
 		}
 
 		public IEnumerable< KeyValuePair< string, IMagentoServiceLowLevelSoap > > GetAll()
@@ -36,7 +38,7 @@ namespace MagentoAccess.Services.Soap
 			};
 
 			var factories = this._factories.OrderBy( x => x.Key ).ToDictionary( x => x.Key, y => y.Value );
-			factories.Add( "1.9.3.x", new MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Factory().CreateMagentoLowLevelService( this._magentoAuthenticatedUserCredentials, this._config ) );
+			factories.Add( "1.9.3.x", new MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Factory().CreateMagentoLowLevelService( this._magentoAuthenticatedUserCredentials, this._config, this._operationsTimeouts ) );
 			
 			Version storeVersion;
 			
@@ -69,8 +71,8 @@ namespace MagentoAccess.Services.Soap
 					return null;
 
 				// try to use 1.7- 1.9 low level service if can't detect version
-				this._factories.Add( magentoVersion, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( this._magentoAuthenticatedUserCredentials, this._config ) );
-				factories.Add( magentoVersion, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( this._magentoAuthenticatedUserCredentials, this._config ) );
+				this._factories.Add( magentoVersion, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( this._magentoAuthenticatedUserCredentials, this._config, this._operationsTimeouts ) );
+				factories.Add( magentoVersion, new MagentoServiceLowLevelSoap_v_1_7_to_1_9_0_1_CE_Factory().CreateMagentoLowLevelService( this._magentoAuthenticatedUserCredentials, this._config, this._operationsTimeouts ) );
 			}
 			return getMagentoLowLevelServiceAndConfigureIt( factories, magentoVersion );
 		}

--- a/src/MagentoAccess/Services/WebRequestServices.cs
+++ b/src/MagentoAccess/Services/WebRequestServices.cs
@@ -35,14 +35,16 @@ namespace MagentoAccess.Services
 		#endregion
 
 		#region ResponseHanding
-		public string GetCurrentHttpClientHeadersRaw()
+		private string GetCurrentHttpClientHeadersRaw()
 		{
-			return JsonConvert.SerializeObject( this._httpClient.DefaultRequestHeaders.Select( kv => new { kv.Key, kv.Value } ) );
+			return JsonConvert.SerializeObject( this._httpClient.DefaultRequestHeaders.Select( kv => new { Header = kv.Key, Value = kv.Value.FirstOrDefault() } ) );
 		}
 
-		public Task< Stream > GetResponseStreamAsync( string method, string url, string authorizationToken, CancellationToken cancellationToken, string body = null, int? operationTimeout = null )
+		public Task< Stream > GetResponseStreamAsync( string method, string url, string authorizationToken, CancellationToken cancellationToken, string body = null, int? operationTimeout = null, Action< string > logHeaders = null )
 		{
 			var httpClient = GetConfiguredHttpClient( authorizationToken );
+
+			logHeaders?.Invoke( GetCurrentHttpClientHeadersRaw() );
 
 			if ( method == WebRequestMethods.Http.Get )
 				return GetRawResponseStreamAsync( httpClient, url, cancellationToken, operationTimeout );

--- a/src/MagentoAccess/Services/WebRequestServices.cs
+++ b/src/MagentoAccess/Services/WebRequestServices.cs
@@ -1,154 +1,102 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
-using Netco.Extensions;
 using Netco.Logging;
+using Newtonsoft.Json;
 
 namespace MagentoAccess.Services
 {
 	internal class WebRequestServices : IWebRequestServices
 	{
-		private const int requestTimeoutMs = 5 * 60 * 1000;
+		private HttpClient _httpClient = new HttpClient();
+		private const int _maxHttpTimeoutInMinutes = 30;
 
 		#region BaseRequests
-		[ Obsolete ]
-		public WebRequest CreateServiceGetRequest( string serviceUrl, Dictionary< string, string > rawUrlParameters )
+		public HttpClient GetConfiguredHttpClient( string authorizationToken )
 		{
-			var parametrizedServiceUrl = serviceUrl;
+			this._httpClient.Timeout = new TimeSpan( 0, _maxHttpTimeoutInMinutes, 0 );
+			
+			this._httpClient.DefaultRequestHeaders.Remove( "Authorization" );
+			this._httpClient.DefaultRequestHeaders.Add( "Authorization", $"Bearer { authorizationToken }" );
 
-			if( rawUrlParameters.Any() )
-			{
-				parametrizedServiceUrl += "?" + rawUrlParameters.Keys.Aggregate( string.Empty,
-					( accum, item ) => accum + "&" + string.Format( "{0}={1}", item, rawUrlParameters[ item ] ) );
-			}
+			this._httpClient.DefaultRequestHeaders.Add( "User-Agent", MagentoService.UserAgentHeader );
 
-			var serviceRequest = ( HttpWebRequest )WebRequest.Create( parametrizedServiceUrl );
-			serviceRequest.Method = WebRequestMethods.Http.Get;
-			//
-			serviceRequest.ContentType = "text/html";
-			serviceRequest.KeepAlive = true;
-			serviceRequest.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-			serviceRequest.CookieContainer = new CookieContainer();
-			serviceRequest.CookieContainer.Add( new Uri( "http://192.168.0.104" ), new Cookie( "PHPSESSID", "mfl1c4qsrjs647chj2ummgo886" ) );
-			serviceRequest.CookieContainer.Add( new Uri( "http://192.168.0.104" ), new Cookie( "adminhtml", "mk8rlurr9c4kaecnneakg55rv7" ) );
-			serviceRequest.Accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8";
-			//
-			return serviceRequest;
-		}
+			// Keep-Alive: true
+			this._httpClient.DefaultRequestHeaders.ConnectionClose = false;
 
-		public async Task< WebRequest > CreateServiceGetRequestAsync( string serviceUrl, string body, Dictionary< string, string > rawHeaders )
-		{
-			return await this.CreateCustomRequestAsync( serviceUrl, body, rawHeaders ).ConfigureAwait( false );
-		}
-
-		public async Task< WebRequest > CreateCustomRequestAsync( string serviceUrl, string body, Dictionary< string, string > rawHeaders, string method = WebRequestMethods.Http.Get, string parameters = null )
-		{
-			try
-			{
-				var compositeUrl = string.IsNullOrEmpty( parameters ) ? serviceUrl : $"{serviceUrl.TrimEnd( '/', '?' )}/?{parameters}";
-
-				var serviceRequest = ( HttpWebRequest )WebRequest.Create( compositeUrl );
-				serviceRequest.Method = method;
-				serviceRequest.ContentType = "application/json";
-				serviceRequest.KeepAlive = true;
-				serviceRequest.Timeout = requestTimeoutMs;
-
-				rawHeaders?.ForEach( k => serviceRequest.Headers.Add( k.Key, k.Value ) );
-				serviceRequest.UserAgent = MagentoService.UserAgentHeader;
-
-				if( ( serviceRequest.Method == WebRequestMethods.Http.Post || serviceRequest.Method == WebRequestMethods.Http.Put ) && !string.IsNullOrWhiteSpace( body ) )
-				{
-					var encodedBody = new UTF8Encoding().GetBytes( body );
-					serviceRequest.ContentLength = encodedBody.Length;
-					using( var newStream = await serviceRequest.GetRequestStreamAsync().ConfigureAwait( false ) )
-						newStream.Write( encodedBody, 0, encodedBody.Length );
-				}
-				return serviceRequest;
-			}
-			catch( Exception exc )
-			{
-				var methodParameters = $@"{{Url:'{serviceUrl}', Body:'{body}', Headers:{rawHeaders.ToJson()}}}";
-				throw new MagentoWebException( $"Exception occured. {this.CreateMethodCallInfo( methodParameters )}", exc );
-			}
-		}
-
-		public void PopulateRequestByBody( string body, HttpWebRequest webRequest )
-		{
-			try
-			{
-				if( !string.IsNullOrWhiteSpace( body ) )
-				{
-					var encodedBody = new UTF8Encoding().GetBytes( body );
-
-					webRequest.ContentLength = encodedBody.Length;
-					webRequest.ContentType = "text/xml";
-					var getRequestStremTask = webRequest.GetRequestStreamAsync();
-					getRequestStremTask.Wait();
-					using( var newStream = getRequestStremTask.Result )
-						newStream.Write( encodedBody, 0, encodedBody.Length );
-				}
-			}
-			catch( Exception exc )
-			{
-				var webrequestUrl = "null";
-
-				if( webRequest != null )
-				{
-					if( webRequest.RequestUri != null )
-					{
-						if( webRequest.RequestUri.AbsoluteUri != null )
-							webrequestUrl = webRequest.RequestUri.AbsoluteUri;
-					}
-				}
-
-				throw new MagentoWebException( $"Exception occured on PopulateRequestByBody(body:{body ?? "null"}, webRequest:{webrequestUrl})", exc );
-			}
+			return this._httpClient;
 		}
 		#endregion
 
 		#region ResponseHanding
-		public Stream GetResponseStream( WebRequest webRequest )
+		public string GetCurrentHttpClientHeadersRaw()
 		{
-			try
-			{
-				using( var response = ( HttpWebResponse )webRequest.GetResponse() )
-				using( var dataStream = response.GetResponseStream() )
-				{
-					var memoryStream = new MemoryStream();
-					if( dataStream != null )
-						dataStream.CopyTo( memoryStream, 0x100 );
-					memoryStream.Position = 0;
-					return memoryStream;
-				}
-			}
-			catch( Exception ex )
-			{
-				var webrequestUrl = "null";
+			return JsonConvert.SerializeObject( this._httpClient.DefaultRequestHeaders.Select( kv => new { kv.Key, kv.Value } ) );
+		}
 
-				if( webRequest != null )
-				{
-					if( webRequest.RequestUri != null )
-					{
-						if( webRequest.RequestUri.AbsoluteUri != null )
-							webrequestUrl = webRequest.RequestUri.AbsoluteUri;
-					}
-				}
+		public Task< Stream > GetResponseStreamAsync( string method, string url, string authorizationToken, CancellationToken cancellationToken, string body = null, int? operationTimeout = null )
+		{
+			var httpClient = GetConfiguredHttpClient( authorizationToken );
 
-				throw new MagentoWebException( $"Exception occured on GetResponseStream( webRequest:{webrequestUrl})", ex );
+			if ( method == WebRequestMethods.Http.Get )
+				return GetRawResponseStreamAsync( httpClient, url, cancellationToken, operationTimeout );
+			else if ( method == WebRequestMethods.Http.Post )
+				return PostAndGetRawResponseStreamAsync( httpClient, url, body, cancellationToken, operationTimeout );
+			else if ( method == WebRequestMethods.Http.Put )
+				return PutAndGetRawResponseStreamAsync( httpClient, url, body, cancellationToken, operationTimeout );
+
+			throw new MagentoWebException( $"Http method {method} isn't supported", null );
+		}
+
+		private async Task< Stream > GetRawResponseStreamAsync( HttpClient client, string url, CancellationToken token, int? operationTimeout = null )
+		{
+			using( var cts = CancellationTokenSource.CreateLinkedTokenSource( token ) )
+			{
+				if ( operationTimeout != null )
+					cts.CancelAfter( operationTimeout.Value );
+
+				var httpResponse = await client.GetAsync( url, cts.Token ).ConfigureAwait( false );
+				return await HandleResponseAsync( httpResponse, url );
 			}
 		}
 
-		public async Task< Stream > GetResponseStreamAsync( WebRequest webRequest, Mark mark = null )
+		private async Task< Stream > PostAndGetRawResponseStreamAsync( HttpClient client, string url, string body, CancellationToken token, int? operationTimeout = null )
+		{
+			using( var cts = CancellationTokenSource.CreateLinkedTokenSource( token ) )
+			{
+				if ( operationTimeout != null )
+					cts.CancelAfter( operationTimeout.Value );
+
+				var content = new StringContent( body, Encoding.UTF8, "application/json" );
+				var httpResponse = await client.PostAsync( url, content, cts.Token ).ConfigureAwait( false );
+				return await HandleResponseAsync( httpResponse, url );
+			}
+		}
+
+		private async Task< Stream > PutAndGetRawResponseStreamAsync( HttpClient client, string url, string body, CancellationToken token, int? operationTimeout = null )
+		{
+			using( var cts = CancellationTokenSource.CreateLinkedTokenSource( token ) )
+			{
+				if ( operationTimeout != null )
+					cts.CancelAfter( operationTimeout.Value );
+
+				var content = new StringContent( body, Encoding.UTF8, "application/json" );
+				var httpResponse = await client.PutAsync( url, content, cts.Token ).ConfigureAwait( false );
+				return await HandleResponseAsync( httpResponse, url );
+			}
+		}
+
+		private async Task< Stream > HandleResponseAsync( HttpResponseMessage responseMessage, string url, Mark mark = null )
 		{
 			try
 			{
-				using( var response = ( HttpWebResponse )await webRequest.GetResponseAsync().ConfigureAwait( false ) )
-				using( var dataStream = await new TaskFactory< Stream >().StartNew( () => response != null ? response.GetResponseStream() : null ).ConfigureAwait( false ) )
+				using( var dataStream = await new TaskFactory< Stream >().StartNew( () => responseMessage.Content.ReadAsStreamAsync().GetAwaiter().GetResult() ).ConfigureAwait( false ) )
 				{
 					var memoryStream = new MemoryStream();
 					if( dataStream != null )
@@ -164,12 +112,7 @@ namespace MagentoAccess.Services
 			}
 			catch( Exception ex )
 			{
-				var webrequestUrl = PredefinedValues.NotAvailable;
-
-				if( webRequest?.RequestUri?.AbsoluteUri != null )
-					webrequestUrl = webRequest.RequestUri.AbsoluteUri;
-
-				throw new MagentoWebException( $"Exception occured on GetResponseStreamAsync( webRequest:{webrequestUrl})", ex );
+				throw new MagentoWebException( $"Exception occured on GetResponseStreamAsync( webRequest:{url})", ex );
 			}
 		}
 		#endregion

--- a/src/MagentoAccess/Services/WebRequestServices.cs
+++ b/src/MagentoAccess/Services/WebRequestServices.cs
@@ -44,7 +44,8 @@ namespace MagentoAccess.Services
 		{
 			var httpClient = GetConfiguredHttpClient( authorizationToken );
 
-			logHeaders?.Invoke( GetCurrentHttpClientHeadersRaw() );
+			if ( logHeaders != null )
+				logHeaders( GetCurrentHttpClientHeadersRaw() );
 
 			if ( method == WebRequestMethods.Http.Get )
 				return GetRawResponseStreamAsync( httpClient, url, cancellationToken, operationTimeout );

--- a/src/MagentoAccess/Services/WebRequestServices.cs
+++ b/src/MagentoAccess/Services/WebRequestServices.cs
@@ -99,6 +99,8 @@ namespace MagentoAccess.Services
 		{
 			try
 			{
+				responseMessage.EnsureSuccessStatusCode();
+
 				using( var dataStream = await new TaskFactory< Stream >().StartNew( () => responseMessage.Content.ReadAsStreamAsync().GetAwaiter().GetResult() ).ConfigureAwait( false ) )
 				{
 					var memoryStream = new MemoryStream();
@@ -115,7 +117,7 @@ namespace MagentoAccess.Services
 			}
 			catch( Exception ex )
 			{
-				throw new MagentoWebException( $"Exception occured on GetResponseStreamAsync( webRequest:{url})", ex );
+				throw new MagentoWebException( $"Exception occured on GetResponseStreamAsync( webRequest:{url})", ex, responseMessage.StatusCode );
 			}
 		}
 		#endregion

--- a/src/MagentoAccessTests/MagentoAccessTests.csproj
+++ b/src/MagentoAccessTests/MagentoAccessTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="MagentoServiceTest.cs" />
     <Compile Include="Misc\ExtensionsTest.cs" />
     <Compile Include="Misc\MagentoServiceFactoryTest.cs" />
+    <Compile Include="Misc\MagentoTimeoutsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Rest\v2x\PagingModelTest.cs" />
     <Compile Include="Services\Rest\v2x\SearchCriteriaTest.cs" />

--- a/src/MagentoAccessTests/MagentoAccessTests.csproj
+++ b/src/MagentoAccessTests/MagentoAccessTests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Misc\ExtensionsTest.cs" />
     <Compile Include="Misc\MagentoServiceFactoryTest.cs" />
     <Compile Include="Misc\MagentoTimeoutsTests.cs" />
+    <Compile Include="Models\GetOrders\OrderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Rest\v2x\PagingModelTest.cs" />
     <Compile Include="Services\Rest\v2x\SearchCriteriaTest.cs" />

--- a/src/MagentoAccessTests/MagentoAccessTests.csproj
+++ b/src/MagentoAccessTests/MagentoAccessTests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Services\Soap\1_7_0_1_ce_1_9_0_1_ce\MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Test.cs" />
     <Compile Include="Services\Soap\1_9_2_1_ce\MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Test.cs" />
     <Compile Include="Services\Soap\2_0_2_0_ce\MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Test.cs" />
+    <Compile Include="Models\GetOrders\Zoey_1_7_to_1_9_CE\ZoeyOrdersExtensionsTests.cs" />
     <Compile Include="TestEnvironment\MagentoServiceLowLevelSoapVFrom17To19CeThrowExcetpionStub.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MagentoAccessTests/MagentoServiceTest.cs
+++ b/src/MagentoAccessTests/MagentoServiceTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using MagentoAccess;
+using MagentoAccess.Misc;
 using MagentoAccess.Models.Credentials;
 using MagentoAccess.Models.PutInventory;
 using MagentoAccess.Services.Soap;
@@ -37,6 +39,7 @@ namespace MagentoAccessTests
 		private const int GetProductsThreadsLimit = 4;
 		private const int SessionLifeTime = 3590;
 		private const bool LogRawMessages = true;
+		private MagentoTimeouts OperationsTimeouts = new MagentoTimeouts();
 
 		[ TestFixtureSetUp ]
 		public void Setup()
@@ -48,34 +51,34 @@ namespace MagentoAccessTests
 		public void GetOrdersAsync_ByDateExceptionOccured_ExceptionThrown()
 		{
 			//------------ Arrange
-			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig() ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
+			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig(), OperationsTimeouts ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
 
 			//------------ Act
 			//------------ Assert
 
-			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.GetOrdersAsync( default(DateTime), default(DateTime) ).ConfigureAwait( false ) );
+			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.GetOrdersAsync( default(DateTime), default(DateTime), CancellationToken.None ).ConfigureAwait( false ) );
 		}
 
 		[ Test ]
 		public void GetProductsAsync_ByDateExceptionOccured_ExceptionThrown()
 		{
 			//------------ Arrange
-			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig() ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
+			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig(), OperationsTimeouts ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
 
 			//------------ Act
 			//------------ Assert
-			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.GetProductsAsync( new[] { 0, 1 } ).ConfigureAwait( false ) );
+			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 } ).ConfigureAwait( false ) );
 		}
 
 		[ Test ]
 		public void PingSoapAsync_ByDateExceptionOccured_ExceptionThrown()
 		{
 			//------------ Arrange
-			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig() ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
+			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig(), OperationsTimeouts ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
 
 			//------------ Act
 			//------------ Assert
-			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.PingSoapAsync().ConfigureAwait( false ) );
+			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.PingSoapAsync( CancellationToken.None ).ConfigureAwait( false ) );
 		}
 
 
@@ -83,11 +86,11 @@ namespace MagentoAccessTests
 		public void UpdateInventoryAsync_ByDateExceptionOccured_ExceptionThrown()
 		{
 			//------------ Arrange
-			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig() ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
+			var magentoService = new MagentoService( this._magentoAuthenticatedUserCredentials, new MagentoConfig(), OperationsTimeouts ) { MagentoServiceLowLevelSoap = this._magentoServiceLowLevelSoapThrowExceptionsStub };
 
 			//------------ Act
 			//------------ Assert
-			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.UpdateInventoryAsync( new List< Inventory > { new Inventory() } ).ConfigureAwait( false ) );
+			Assert.ThrowsAsync< MagentoCommonException >( async () => await magentoService.UpdateInventoryAsync( new List< Inventory > { new Inventory() }, CancellationToken.None ).ConfigureAwait( false ) );
 		}
 	}
 }

--- a/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
+++ b/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
@@ -6,6 +6,7 @@ using MagentoAccess;
 using MagentoAccess.Misc;
 using MagentoAccess.Models.Credentials;
 using MagentoAccess.Models.GetProducts;
+using MagentoAccess.Models.GetShipments;
 using MagentoAccess.Models.Services.Soap.GetCategoryTree;
 using MagentoAccess.Models.Services.Soap.GetMagentoInfo;
 using MagentoAccess.Models.Services.Soap.GetOrders;
@@ -137,7 +138,7 @@ namespace MagentoAccessTests.Misc
 				return null;
 			}
 
-			public Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+			public Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField )
 			{
 				return null;
 			}
@@ -268,6 +269,11 @@ namespace MagentoAccessTests.Misc
 			}
 
 			public Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, IReadOnlyCollection< string > skus )
+			{
+				throw new NotImplementedException();
+			}
+
+			public Task<Dictionary< string, IEnumerable< Shipment > > > GetOrdersShipmentsAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 			{
 				throw new NotImplementedException();
 			}

--- a/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
+++ b/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
@@ -113,6 +113,11 @@ namespace MagentoAccessTests.Misc
 				return string.Empty;
 			}
 
+			public DateTime? LastActivityTime
+			{
+				get { return null; }
+			}
+
 			public Task< bool > InitAsync( bool supressExceptions = false )
 			{
 				try

--- a/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
+++ b/src/MagentoAccessTests/Misc/MagentoServiceFactoryTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess;
 using MagentoAccess.Misc;
@@ -32,7 +33,7 @@ namespace MagentoAccessTests.Misc
 		public string GetMagentoSubVersion_InputIsCorrectVersion_SubversionReturned( int deep, string magentoVer )
 		{
 			//------------ Arrange
-			var magentoServiceLowLevelSoapFactory = new MagentoServiceLowLevelSoapFactory( null, null, null );
+			var magentoServiceLowLevelSoapFactory = new MagentoServiceLowLevelSoapFactory( null, null, null, null );
 
 			//------------ Act
 			var version = magentoServiceLowLevelSoapFactory.GetSubVersion( deep, magentoVer );
@@ -70,7 +71,7 @@ namespace MagentoAccessTests.Misc
 				{ s7.Store, s7 },
 				{ s8.Store, s8 },
 			};
-			var magentoServiceLowLevelSoapFactory = new MagentoServiceLowLevelSoapFactory( new MagentoAuthenticatedUserCredentials( "", "", "http://base.url", "", "", "", "", 0, 0, false ), factories, null );
+			var magentoServiceLowLevelSoapFactory = new MagentoServiceLowLevelSoapFactory( new MagentoAuthenticatedUserCredentials( "", "", "http://base.url", "", "", "", "", 0, 0, false ), factories, null, null );
 
 			//------------ Act
 			var magentoServiceLowLevelSoap = magentoServiceLowLevelSoapFactory.GetMagentoServiceLowLevelSoap( magentoVer, true, false );
@@ -126,47 +127,47 @@ namespace MagentoAccessTests.Misc
 				}
 			}
 
-			public Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+			public Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 			{
 				return null;
 			}
 
-			public Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+			public Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null )
+			public Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null )
 			{
 				return null;
 			}
 
-			public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, Mark mark = null )
+			public Task< SoapGetProductsResponse > GetProductsBySkusAsync(  IEnumerable< string > skus, CancellationToken cancellationToken, Mark mark = null )
 			{
 				return null;
 			}
 
-			public Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+			public Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 			{
 				return null;
 			}
 
-			public Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+			public Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 			{
 				return null;
 			}
 
-			public Task< OrderInfoResponse > GetOrderAsync( Order order, Mark childMark )
+			public Task< OrderInfoResponse > GetOrderAsync( Order order, CancellationToken cancellationToken, Mark childMark )
 			{
 				return null;
 			}
 
-			Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > IMagentoServiceLowLevelSoap.PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark )
+			Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > IMagentoServiceLowLevelSoap.PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark )
 			{
 				throw new NotImplementedException();
 			}
 
-			public Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+			public Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 			{
 				return null;
 			}
@@ -176,87 +177,87 @@ namespace MagentoAccessTests.Misc
 				return null;
 			}
 
-			public Task< bool > PutStockItemAsync( PutStockItem putStockItem, Mark markForLog )
+			public Task< bool > PutStockItemAsync( PutStockItem putStockItem, CancellationToken cancellationToken, Mark markForLog )
 			{
 				return null;
 			}
 
-			public Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, Mark markForLog )
+			public Task< int > CreateProduct( string storeId, string name, string sku, int isInStock, string productType, CancellationToken cancellationToken, Mark markForLog )
 			{
 				return null;
 			}
 
-			public Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType )
+			public Task< bool > DeleteProduct( string storeId, int categoryId, string productId, string identiferType, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< int > CreateCart( string storeid )
+			public Task< int > CreateCart( string storeid, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store )
+			public Task< bool > ShoppingCartGuestCustomerSet( int shoppingCart, string customerfirstname, string customerMail, string customerlastname, string store, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< bool > ShoppingCartAddressSet( int shoppingCart, string store )
+			public Task< bool > ShoppingCartAddressSet( int shoppingCart, string store, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store )
+			public Task< bool > ShoppingCartAddProduct( int shoppingCartId, string productId, string store, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store )
+			public Task< bool > ShoppingCartSetShippingMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store )
+			public Task< bool > ShoppingCartSetPaymentMethod( int shoppingCartId, string store, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< string > CreateOrder( int shoppingcartid, string store )
+			public Task< string > CreateOrder( int shoppingcartid, string store, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< GetSessionIdResponse > GetSessionId( bool throwException = true )
+			public Task< GetSessionIdResponse > GetSessionId( CancellationToken cancellationToken, bool throwException = true )
 			{
 				return null;
 			}
 
-			public Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest catalogProductInfoRequest, bool throwException = true )
+			public Task< CatalogProductInfoResponse > GetProductInfoAsync( CatalogProductInfoRequest catalogProductInfoRequest, CancellationToken cancellationToken, bool throwException = true )
 			{
 				return null;
 			}
 
-			public Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, bool throwException = true )
+			public Task< ProductAttributeMediaListResponse > GetProductAttributeMediaListAsync( GetProductAttributeMediaListRequest getProductAttributeMediaListRequest, CancellationToken cancellationToken, bool throwException = true )
 			{
 				return null;
 			}
 
-			public Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( string rootCategory = "1" )
+			public Task< GetCategoryTreeResponse > GetCategoriesTreeAsync( CancellationToken cancellationToken, string rootCategory = "1" )
 			{
 				return null;
 			}
 
-			public Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute )
+			public Task< CatalogProductAttributeInfoResponse > GetManufacturersInfoAsync( string attribute, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts )
+			public Task< IEnumerable< ProductDetails > > FillProductDetails( IEnumerable< ProductDetails > resultProducts, CancellationToken cancellationToken )
 			{
 				return null;
 			}
 
-			public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+			public Task< InventoryStockItemListResponse > GetStockItemsWithoutSkuAsync( IEnumerable< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 			{
 				throw new NotImplementedException();
 			}

--- a/src/MagentoAccessTests/Misc/MagentoTimeoutsTests.cs
+++ b/src/MagentoAccessTests/Misc/MagentoTimeoutsTests.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using MagentoAccess.Misc;
+using NUnit.Framework;
+
+namespace MagentoAccessTests.Misc
+{
+	[ TestFixture ]
+	public class MagentoTimeoutsTests
+	{
+		[ Test ]
+		public void GivenSpecificTimeoutsAreNotSet_WhenGetTimeoutIsCalled_ThenDefaultTimeoutIsReturned()
+		{
+			var operationsTimeouts = new MagentoTimeouts();
+
+			operationsTimeouts[ MagentoOperationEnum.GetModifiedOrders ].Should().Be( operationsTimeouts.DefaultOperationTimeout.TimeoutInMs );
+		}
+
+		[ Test ]
+		public void GivenOwnDefaultTimeoutValue_WhenGetTimeoutIsCalled_ThenOverridenDefaultTimeoutIsReturned()
+		{
+			var newDefaultTimeoutInMs = 10 * 60 * 1000;
+			var operationsTimeouts = new MagentoTimeouts( newDefaultTimeoutInMs );
+
+			operationsTimeouts[ MagentoOperationEnum.GetProductBySku ].Should().Be( newDefaultTimeoutInMs );
+		}
+
+		[ Test ]
+		public void GivenGetModifiedOrdersTimeoutIsSet_WhenGetTimeoutIsCalled_ThenSpecificTimeoutIsReturned()
+		{
+			var operationsTimeouts = new MagentoTimeouts();
+			var specificTimeoutInMs = 10 * 60 * 1000;
+			operationsTimeouts.Set( MagentoOperationEnum.GetModifiedOrders, new MagentoOperationTimeout( specificTimeoutInMs ) );
+
+			operationsTimeouts[ MagentoOperationEnum.GetModifiedOrders ].Should().Be( specificTimeoutInMs );
+			operationsTimeouts[ MagentoOperationEnum.GetProductBySku ].Should().Be( operationsTimeouts.DefaultOperationTimeout.TimeoutInMs );
+		}
+
+		[ Test ]
+		public void GivenGetModifiedOrdersTimeoutIsSetTwice_WhenGetTimeoutIsCalled_ThenSpecificTimeoutIsReturned()
+		{
+			var operationsTimeouts = new MagentoTimeouts();
+			var specificTimeoutInMs = 10 * 60 * 1000;
+			operationsTimeouts.Set( MagentoOperationEnum.GetModifiedOrders, new MagentoOperationTimeout( specificTimeoutInMs ) );
+			operationsTimeouts.Set( MagentoOperationEnum.GetModifiedOrders, new MagentoOperationTimeout( specificTimeoutInMs * 2 ) );
+
+			operationsTimeouts[ MagentoOperationEnum.GetModifiedOrders ].Should().Be( specificTimeoutInMs * 2 );
+		}
+	}
+}

--- a/src/MagentoAccessTests/Models/GetOrders/OrderTests.cs
+++ b/src/MagentoAccessTests/Models/GetOrders/OrderTests.cs
@@ -1,0 +1,95 @@
+﻿using FluentAssertions;
+using MagentoAccess.Models.GetOrders;
+using MagentoAccess.Models.Services.Soap.GetOrders;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using Order = MagentoAccess.Models.GetOrders.Order;
+
+namespace MagentoAccessTests.Models.GetOrders
+{
+	[ TestFixture ]
+	public class OrderTests
+	{
+		[ Test ]
+		public void OrderConstructor_ParameterOrderInfoResponse_GivenNullItems_ShouldReturnEmptyItems()
+		{
+			var orderInfoResponse = new OrderInfoResponse();
+
+			var result = new Order( orderInfoResponse );
+
+			result.Items.Should().BeEmpty();
+		}
+	}
+		
+	public class OrderExtensionsTests
+	{
+		[ Test ]
+		public void ToSvOrderItems_ParameterListOrderItemEntity_GivenNullItems_ShouldReturnEmptyItems()
+		{
+			List< OrderItemEntity > orderItems = null;
+
+			var result = orderItems.ToSvOrderItems().ToList();
+
+			result.Should().BeEmpty();
+		}
+
+		[ Test ]
+		public void ToSvOrderItems_ParameterListOrderItemEntity_ShouldReturnCorrectItems()
+		{
+			var orderItem = new OrderItemEntity
+			{
+				BaseDiscountAmount = "1.23",
+				BaseOriginalPrice = "2.34",
+				Sku = "testSku23",
+				Name = "Some product",
+				BaseTaxAmount = "0.40",
+				ItemId = "12345",
+				BasePrice = "22.33",
+				BaseRowTotal = "34.43",
+				DiscountAmount = "43.34",
+				OriginalPrice = "5.5",
+				Price = "2.22",
+				ProductType = "spoon",
+				QtyCanceled = "123",
+				QtyInvoiced = "3",
+				QtyOrdered = "1233",
+				QtyShipped = "7",
+				QtyRefunded = "1",
+				RowTotal = "2.34",
+				TaxAmount = "0.01",
+				TaxPercent = "6.01"
+			};
+			var orderItems = new List< OrderItemEntity >
+			{
+				orderItem,
+				new OrderItemEntity()
+			};
+
+			var result = orderItems.ToSvOrderItems().ToList();
+
+			result.Count.Should().Be( orderItems.Count );
+			var resultFirst = result.First();
+			resultFirst.BaseDiscountAmount.ToString().Should().Be( orderItem.BaseDiscountAmount );
+			resultFirst.BaseOriginalPrice.ToString().Should().Be( orderItem.BaseOriginalPrice );
+			resultFirst.Sku.Should().Be( orderItem.Sku );
+			resultFirst.Name.Should().Be( orderItem.Name );
+			resultFirst.BaseTaxAmount.ToString().Should().Be( orderItem.BaseTaxAmount );
+			resultFirst.ItemId.Should().Be( orderItem.ItemId );
+			resultFirst.BasePrice.ToString().Should().Be( orderItem.BasePrice );
+			resultFirst.BaseRowTotal.ToString().Should().Be( orderItem.BaseRowTotal );
+			resultFirst.DiscountAmount.ToString().Should().Be( orderItem.DiscountAmount );
+			resultFirst.OriginalPrice.ToString().Should().Be( orderItem.OriginalPrice );
+			resultFirst.Price.ToString().Should().Be( orderItem.Price );
+			resultFirst.ProductType.Should().Be( orderItem.ProductType );
+			resultFirst.QtyCanceled.ToString().Should().Be( orderItem.QtyCanceled );
+			resultFirst.QtyInvoiced.ToString().Should().Be( orderItem.QtyInvoiced );
+			resultFirst.QtyOrdered.ToString().Should().Be( orderItem.QtyOrdered );
+			resultFirst.QtyShipped.ToString().Should().Be( orderItem.QtyShipped );
+			resultFirst.QtyRefunded.ToString().Should().Be( orderItem.QtyRefunded );
+			resultFirst.RowTotal.ToString().Should().Be( orderItem.RowTotal );
+			resultFirst.TaxAmount.ToString().Should().Be( orderItem.TaxAmount );
+			resultFirst.TaxPercent.ToString().Should().Be( orderItem.TaxPercent );
+		}
+	}
+}

--- a/src/MagentoAccessTests/Models/GetOrders/Zoey_1_7_to_1_9_CE/ZoeyOrdersExtensionsTests.cs
+++ b/src/MagentoAccessTests/Models/GetOrders/Zoey_1_7_to_1_9_CE/ZoeyOrdersExtensionsTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using FluentAssertions;
+using MagentoAccess.Models.Services.Soap.GetOrders;
+using NUnit.Framework;
+using MagentoAccess.TsZoey_v_1_9_0_1_CE;
+
+namespace MagentoAccessTests.Models.GetOrders.Zoey_1_7_to_1_9_CE
+{
+	[ TestFixture ]
+	public class ZoeyOrdersExtensionsTests
+	{
+		[ Test ]
+		public void ToOrderItemEntities_ThenOrderItemCreated()
+		{
+			var orderInvoiceDiscount = "1.23";
+			var sku = "testSku1";
+			var qty = "3";
+			var price = "11.23";
+			var taxAmount = "2.34";
+			salesOrderInvoiceEntity[] orderInvoices = new []
+			{
+				new salesOrderInvoiceEntity
+				{
+					items = new []
+					{
+						new salesOrderInvoiceItemEntity 
+						{ 
+							sku = sku, 
+							qty = qty,
+							price = price,
+							tax_amount = taxAmount
+						}
+					},
+					discount_amount = orderInvoiceDiscount
+				},
+				new salesOrderInvoiceEntity
+				{
+					items = new [] { new salesOrderInvoiceItemEntity() }
+				}
+			};
+
+			var results = orderInvoices.ToOrderItemEntities();
+
+			results.Count().Should().Be( orderInvoices.Length );
+			var resultsFirst = results.First();
+			resultsFirst.Sku.Should().Be( sku );
+			resultsFirst.QtyOrdered.Should().Be( qty );
+			resultsFirst.Price.Should().Be( price );
+			resultsFirst.DiscountAmount.Should().Be( orderInvoiceDiscount );
+			resultsFirst.TaxAmount.Should().Be( taxAmount );
+		}
+
+		[ Test ]
+		public void ToOrderItemEntities_WhenOrderInvoicesIsNull_ThenReturnsEmpty()
+		{ 
+			salesOrderInvoiceEntity[] orderInvoices = null;
+
+			var results = orderInvoices.ToOrderItemEntities();
+
+			results.Should().BeEmpty();
+		}
+
+		[ Test ]
+		public void ToOrderItemEntities_WhenMultipleInvoicesItemsPerInvoice_ThenItemDiscountIsEmptyString()
+		{ 
+			salesOrderInvoiceEntity[] orderInvoices = new []
+			{
+				new salesOrderInvoiceEntity
+				{
+					items = new []
+					{
+						new salesOrderInvoiceItemEntity { sku = "testSku1" },
+						new salesOrderInvoiceItemEntity { sku = "testSku2" }
+					},
+					discount_amount = "1.23"
+				}
+			};
+
+			var results = orderInvoices.ToOrderItemEntities();
+
+			results.First().DiscountAmount.Should().BeEmpty();
+		}
+	}
+}

--- a/src/MagentoAccessTests/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Test.cs
+++ b/src/MagentoAccessTests/Services/Soap/1_14_1_0_ee/MagentoServiceLowLevelSoap_v_1_14_1_0_EE_Test.cs
@@ -34,7 +34,7 @@ namespace MagentoAccessTests.Services.Soap._1_14_1_0_ee
 			}
 
 			//A
-			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await serviceLowLevelSoapV11410Ee.GetSessionId( false ).ConfigureAwait( false ) );
+			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await serviceLowLevelSoapV11410Ee.GetSessionId( CancellationToken.None, false ).ConfigureAwait( false ) );
 			getSessionTasks.Wait();
 
 			//A

--- a/src/MagentoAccessTests/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Test.cs
+++ b/src/MagentoAccessTests/Services/Soap/1_7_0_1_ce_1_9_0_1_ce/MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Test.cs
@@ -34,7 +34,7 @@ namespace MagentoAccessTests.Services.Soap._1_7_0_1_ce_1_9_0_1_ce
 			}
 
 			//A
-			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await magentoServiceLowLevelSoapVFrom17To19Ce.GetSessionId( false ).ConfigureAwait( false ) );
+			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await magentoServiceLowLevelSoapVFrom17To19Ce.GetSessionId( CancellationToken.None, false ).ConfigureAwait( false ) );
 			getSessionTasks.Wait();
 
 			//A

--- a/src/MagentoAccessTests/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Test.cs
+++ b/src/MagentoAccessTests/Services/Soap/1_9_2_1_ce/MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Test.cs
@@ -34,7 +34,7 @@ namespace MagentoAccessTests.Services.Soap._1_9_2_1_ce
 			}
 
 			//A
-			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await magentoServiceLowLevelSoapV1921Ce.GetSessionId( false ).ConfigureAwait( false ) );
+			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await magentoServiceLowLevelSoapV1921Ce.GetSessionId( CancellationToken.None, false ).ConfigureAwait( false ) );
 			getSessionTasks.Wait();
 
 			//A

--- a/src/MagentoAccessTests/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Test.cs
+++ b/src/MagentoAccessTests/Services/Soap/2_0_2_0_ce/MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Test.cs
@@ -34,7 +34,7 @@ namespace MagentoAccessTests.Services.Soap._2_0_2_0_ce
 			}
 
 			//A
-			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await magentoServiceLowLevelSoapV2020Ce.GetSessionId( false ).ConfigureAwait( false ) );
+			var getSessionTasks = list.ProcessInBatchAsync( tasksCount, async x => await magentoServiceLowLevelSoapV2020Ce.GetSessionId( CancellationToken.None, false ).ConfigureAwait( false ) );
 			getSessionTasks.Wait();
 
 			//A

--- a/src/MagentoAccessTests/TestEnvironment/MagentoServiceLowLevelSoapVFrom17To19CeThrowExcetpionStub.cs
+++ b/src/MagentoAccessTests/TestEnvironment/MagentoServiceLowLevelSoapVFrom17To19CeThrowExcetpionStub.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MagentoAccess;
 using MagentoAccess.Misc;
@@ -20,37 +21,37 @@ namespace MagentoAccessTests.TestEnvironment
 		{
 		}
 
-		public override Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, Mark mark = null )
+		public override Task< GetMagentoInfoResponse > GetMagentoInfoAsync( bool suppressException, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new Exception();
 		}
 
-		public override Task< OrderInfoResponse > GetOrderAsync( string incrementId, Mark childMark )
+		public override Task< OrderInfoResponse > GetOrderAsync( string incrementId, CancellationToken cancellationToken, Mark childMark )
 		{
 			throw new Exception();
 		}
 
-		public override Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, Mark mark = null )
+		public override Task< GetOrdersResponse > GetOrdersAsync( DateTime modifiedFrom, DateTime modifiedTo, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new Exception();
 		}
 
-		public override Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds )
+		public override Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
 		{
 			throw new Exception();
 		}
 
-		public override Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, Mark mark = null )
+		public override Task< SoapGetProductsResponse > GetProductsAsync( string productType, bool productTypeShouldBeExcluded, DateTime? updatedFrom, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new Exception();
 		}
 
-		public override Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, Mark mark = null )
+		public override Task< InventoryStockItemListResponse > GetStockItemsAsync( List< string > skusOrIds, IEnumerable< int > scopes, CancellationToken cancellationToken, Mark mark = null )
 		{
 			throw new Exception();
 		}
 
-		public override Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, Mark mark )
+		public override Task< IEnumerable< RpcInvoker.RpcRequestResponse< PutStockItem, object > > > PutStockItemsAsync( List< PutStockItem > stockItems, CancellationToken cancellationToken, Mark mark )
 		{
 			throw new Exception();
 		}

--- a/src/MagentoAccessTests/TestEnvironment/MagentoServiceLowLevelSoapVFrom17To19CeThrowExcetpionStub.cs
+++ b/src/MagentoAccessTests/TestEnvironment/MagentoServiceLowLevelSoapVFrom17To19CeThrowExcetpionStub.cs
@@ -36,7 +36,7 @@ namespace MagentoAccessTests.TestEnvironment
 			throw new Exception();
 		}
 
-		public override Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken )
+		public override Task< GetOrdersResponse > GetOrdersAsync( IEnumerable< string > ordersIds, CancellationToken cancellationToken, string searchField )
 		{
 			throw new Exception();
 		}

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetOrders/ReceiveOrders.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetOrders/ReceiveOrders.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -30,13 +31,13 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.GetOrders
 			var modifiedTo = new DateTime( 2017, 7, 2, 23, 30, 39 ).AddSeconds( -1 );
 
 			var swR = Stopwatch.StartNew();
-			var getOrdersTaskRest = magentoServiceRest.GetOrdersAsync( modifiedFrom, modifiedTo, new Mark( "TEST-GET-ORDERS" ) );
+			var getOrdersTaskRest = magentoServiceRest.GetOrdersAsync( modifiedFrom, modifiedTo, CancellationToken.None, new Mark( "TEST-GET-ORDERS" ) );
 			getOrdersTaskRest.Wait();
 			swR.Stop();
 
 			Task.Delay( 10000 ).Wait();
 			var swS = Stopwatch.StartNew();
-			var getOrdersTask2 = magentoServiceSoap.GetOrdersAsync( modifiedFrom, modifiedTo, new Mark( "TEST-GET-ORDERS-2" ) );
+			var getOrdersTask2 = magentoServiceSoap.GetOrdersAsync( modifiedFrom, modifiedTo, CancellationToken.None, new Mark( "TEST-GET-ORDERS-2" ) );
 			getOrdersTask2.Wait();
 			swS.Stop();
 

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetOrders/ReceiveOrders.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetOrders/ReceiveOrders.cs
@@ -95,5 +95,20 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.GetOrders
 			thatWasReturnedRest.Should().BeEquivalentTo( thatWasReturnedSoap );
 			swS.Elapsed.Should().BeGreaterThan( swR.Elapsed );// I know this thing shouldn't be tested here. I hope, it will be fixed soon and will be moved to appropriate place
 		}
+
+		[ Test ]
+		[ TestCaseSource( typeof( InterchangeabilityTestCases ), nameof(InterchangeabilityTestCases.TestStoresCredentials) ) ]
+		public void WhenGetOrdersAsyncIsCalled_ThenModifiedLastActivityTimeIsExpected( MagentoServiceCredentialsAndConfig credentialsRest, MagentoServiceCredentialsAndConfig credentialsSoap )
+		{
+			var magentoServiceRest = this.CreateMagentoService( credentialsRest.AuthenticatedUserCredentials.SoapApiUser, credentialsRest.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentialsRest.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentialsRest.Config.VersionByDefault, credentialsRest.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentialsRest.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentialsRest.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
+			var modifiedFrom = new DateTime( 2017, 6, 2, 23, 23, 59 ).AddSeconds( 1 );
+			var modifiedTo = new DateTime( 2017, 7, 2, 23, 30, 39 ).AddSeconds( -1 );
+			var lastActivityTimeBeforeMakingAnyRequest = magentoServiceRest.LastActivityTime;
+
+			magentoServiceRest.GetOrdersAsync( modifiedFrom, modifiedTo, CancellationToken.None, new Mark( "TEST-GET-ORDERS" ) ).Wait();
+
+			var lastActivityTimeAfterMakingRequests = magentoServiceRest.LastActivityTime;
+			lastActivityTimeAfterMakingRequests.Should().BeAfter( lastActivityTimeBeforeMakingAnyRequest );
+		}
 	}
 }

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/FillProductsDetails.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/FillProductsDetails.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -24,21 +25,21 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.GetProducts
 			var magentoServiceRest = this.CreateMagentoService( credentialsRest.AuthenticatedUserCredentials.SoapApiUser, credentialsRest.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentialsRest.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentialsRest.Config.VersionByDefault, credentialsRest.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentialsRest.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentialsRest.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 			var magentoServiceSoap = this.CreateMagentoService( credentialsSoap.AuthenticatedUserCredentials.SoapApiUser, credentialsSoap.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentialsSoap.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentialsSoap.Config.VersionByDefault, credentialsSoap.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentialsSoap.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentialsRest.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
-			var getProductsSoapTask = magentoServiceSoap.GetProductsAsync( new[] { 0, 1 }, includeDetails : false );
+			var getProductsSoapTask = magentoServiceSoap.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : false );
 			getProductsSoapTask.Wait();
 			var productsList = getProductsSoapTask.Result;
 
 			// ------------ Act
 			var swR = Stopwatch.StartNew();
 			var productsListRest = productsList.Select( p => p.DeepClone() );
-			var fillProductsDetailsRest = magentoServiceRest.FillProductsDetailsAsync( productsListRest );
+			var fillProductsDetailsRest = magentoServiceRest.FillProductsDetailsAsync( productsListRest, CancellationToken.None );
 			fillProductsDetailsRest.Wait();
 			swR.Stop();
 
 			Task.Delay( 500 ).Wait();
 			var swS = Stopwatch.StartNew();
 			var productsListSoap = productsList.Select( p => p.DeepClone() );
-			var fillProductsDetailsSoap = magentoServiceSoap.FillProductsDetailsAsync( productsListSoap );
+			var fillProductsDetailsSoap = magentoServiceSoap.FillProductsDetailsAsync( productsListSoap, CancellationToken.None );
 			fillProductsDetailsSoap.Wait();
 			swS.Stop();
 

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/ReceiveProductsBySku.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/ReceiveProductsBySku.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -26,13 +27,13 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.GetProducts
 
 			// ------------ Act
 			var swR = Stopwatch.StartNew();
-			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( new[] { 0, 1 }, skus : skus, includeDetails : true );
+			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : skus, includeDetails : true );
 			getProductsTaskRest.Wait();
 			swR.Stop();
 
 			Task.Delay( 500 ).Wait();
 			var swS = Stopwatch.StartNew();
-			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( new[] { 0, 1 }, skus : skus, includeDetails : true );
+			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : skus, includeDetails : true );
 			getProductsTaskSoap.Wait();
 			swS.Stop();
 

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/ReceiveProductsWithDetalis.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/ReceiveProductsWithDetalis.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -25,13 +26,13 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.GetProducts
 
 			// ------------ Act
 			var swR = Stopwatch.StartNew();
-			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( new[] { 0, 1 }, includeDetails : true );
+			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true );
 			getProductsTaskRest.Wait();
 			swR.Stop();
 
 			Task.Delay( 500 ).Wait();
 			var swS = Stopwatch.StartNew();
-			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( new[] { 0, 1 }, includeDetails : true );
+			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true );
 			getProductsTaskSoap.Wait();
 			swS.Stop();
 

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/ReceiveProductsWithoutDetalis.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/GetProducts/ReceiveProductsWithoutDetalis.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -24,13 +25,13 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.GetProducts
 
 			// ------------ Act
 			var swR = Stopwatch.StartNew();
-			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( new[] { 0, 1 }, includeDetails : false );
+			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : false );
 			getProductsTaskRest.Wait();
 			swR.Stop();
 
 			Task.Delay( 500 ).Wait();
 			var swS = Stopwatch.StartNew();
-			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( new[] { 0, 1 }, includeDetails : false );
+			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : false );
 			getProductsTaskSoap.Wait();
 			swS.Stop();
 

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/UpdateInventory/UpdateInventory.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/UpdateInventory/UpdateInventory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -23,13 +24,13 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.UpdateInventory
 			var skus = new string[] { "testsku1", "testsku2", "testsku3", "testsku4" };
 
 			// ------------ Act
-			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( new[] { 0, 1 }, skus : skus, includeDetails : true );
+			var getProductsTaskRest = magentoServiceRest.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : skus, includeDetails : true );
 			getProductsTaskRest.Wait();
 			var inventoryToUpdate = getProductsTaskRest.Result.Where( p => p.ProductType == "simple" ).OrderBy( p => p.ProductId ).Select( p => new Inventory() { ItemId = p.ProductId, ProductId = p.ProductId, Sku = p.Sku, Qty = long.Parse( p.Qty ) + 1 } );
-			magentoServiceRest.UpdateInventoryAsync( inventoryToUpdate );
+			magentoServiceRest.UpdateInventoryAsync( inventoryToUpdate, CancellationToken.None );
 
 			Task.Delay( 2000 ).Wait();
-			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( new[] { 0, 1 }, skus : skus, includeDetails : true );
+			var getProductsTaskSoap = magentoServiceSoap.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : skus, includeDetails : true );
 			getProductsTaskSoap.Wait();
 			var updatedInventory = getProductsTaskSoap.Result.Where( p => p.ProductType == "simple" ).OrderBy( p => p.ProductId ).Select( p => new Inventory() { ItemId = p.ProductId, ProductId = p.ProductId, Sku = p.Sku, Qty = long.Parse( p.Qty ) } );
 

--- a/src/MagentoAccessTestsIntegration/InterchangeabilityTests/UpdateInventory/UpdateInventoryBySku.cs
+++ b/src/MagentoAccessTestsIntegration/InterchangeabilityTests/UpdateInventory/UpdateInventoryBySku.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -23,13 +24,13 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.UpdateInventory
 			var skus = new[] { "testsku1", "testsku2", "testsku3", "testsku4" };
 
 			// ------------ Act
-			var getProductsRestTask = magentoServiceRest.GetProductsAsync( new[] { 0, 1 }, skus : skus, includeDetails : false );
+			var getProductsRestTask = magentoServiceRest.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : skus, includeDetails : false );
 			getProductsRestTask.Wait();
 			var inventoryToUpdate = getProductsRestTask.Result.Where( p => p.ProductType == "simple" ).OrderBy( p => p.ProductId ).Select( p => new InventoryBySku() { Sku = p.Sku, Qty = long.Parse( p.Qty ) + 1 } );
-			magentoServiceRest.UpdateInventoryBySkuAsync( inventoryToUpdate );
+			magentoServiceRest.UpdateInventoryBySkuAsync( inventoryToUpdate, CancellationToken.None );
 
 			Task.Delay( 2000 ).Wait();
-			var getProductsSoapTask = magentoServiceSoap.GetProductsAsync( new[] { 0, 1 }, skus : skus, includeDetails : false );
+			var getProductsSoapTask = magentoServiceSoap.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : skus, includeDetails : false );
 			getProductsSoapTask.Wait();
 			var updatedInventory = getProductsSoapTask.Result.Where( p => p.ProductType == "simple" ).OrderBy( p => p.ProductId ).Select( p => new InventoryBySku { Sku = p.Sku, Qty = long.Parse( p.Qty ) } );
 
@@ -47,12 +48,12 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.UpdateInventory
 
 			// update to zero quantity first
 			var updateSkuQuantityToZeroRequest = new InventoryBySku() { Sku = sku, Qty = 0 };
-			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityToZeroRequest } );
+			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityToZeroRequest }, CancellationToken.None );
 
 			var updateSkuQuantityRequest = new InventoryBySku() { Sku = sku, Qty = newQuantity };
-			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityRequest } );
+			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityRequest }, CancellationToken.None );
 
-			var searchProductsResult = magentoServiceRest.GetProductsAsync( new[] { 0, 1 }, skus : new string[] { sku }, includeDetails : false ).Result;
+			var searchProductsResult = magentoServiceRest.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : new string[] { sku }, includeDetails : false ).Result;
 			var updatedProduct = searchProductsResult.First();
 
 			// ------------ Assert
@@ -70,12 +71,12 @@ namespace MagentoAccessTestsIntegration.InterchangeabilityTests.UpdateInventory
 			var magentoServiceRest = this.CreateMagentoService( credentialsRest.AuthenticatedUserCredentials.SoapApiUser, credentialsRest.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentialsRest.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentialsRest.Config.VersionByDefault, credentialsRest.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentialsRest.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentialsRest.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
 			var updateSkuQuantityToZeroRequest = new InventoryBySku() { Sku = sku, Qty = previousQuantity };
-			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityToZeroRequest } );
+			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityToZeroRequest }, CancellationToken.None );
 
 			var updateSkuQuantityRequest = new InventoryBySku() { Sku = sku, Qty = newQuantity };
-			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityRequest } );
+			await magentoServiceRest.UpdateInventoryBySkuAsync( new InventoryBySku[] { updateSkuQuantityRequest }, CancellationToken.None );
 
-			var searchProductsResult = magentoServiceRest.GetProductsAsync( new[] { 0, 1 }, skus : new string[] { sku }, includeDetails : false ).Result;
+			var searchProductsResult = magentoServiceRest.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, skus : new string[] { sku }, includeDetails : false ).Result;
 			var updatedProduct = searchProductsResult.First();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoAccessTestsIntegration.csproj
+++ b/src/MagentoAccessTestsIntegration/MagentoAccessTestsIntegration.csproj
@@ -105,6 +105,7 @@
     <Content Include="InterchangeabilityTests\Readme.txt" />
     <Content Include="MagentoServiceTests\Readme.txt" />
     <Compile Include="MagentoServiceTests\FillProductsDetails\GetProducsAndFillProductsDetails.cs" />
+    <Compile Include="MagentoServiceTests\GetShipments\GetShipmentsTest.cs" />
     <Compile Include="MagentoServiceTests\UpdateInventory\GetOnlySpecialByTypeProducs.cs" />
     <Compile Include="MagentoServiceTests\GetProductsAsync\GetProducsWithUpdateTimeAndSkusFilter.cs" />
     <Compile Include="MagentoServiceTests\GetProductsAsync\GetProducsWithUpdateTimeFilter.cs" />

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTest.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccess.Misc;
@@ -22,14 +23,14 @@ namespace MagentoAccessTestsIntegration
 			//------------ Act
 			var onlyProductsCreatedForThisTests = this.GetOnlyProductsCreatedForThisTests( magentoService );
 			var updateFirstTimeQty = 123;
-			var updateInventoryTask = magentoService.UpdateInventoryAsync( onlyProductsCreatedForThisTests.ToInventory( x => updateFirstTimeQty ).ToList() );
+			var updateInventoryTask = magentoService.UpdateInventoryAsync( onlyProductsCreatedForThisTests.ToInventory( x => updateFirstTimeQty ).ToList(), CancellationToken.None );
 			updateInventoryTask.Wait();
 
 			/////
 			var onlyProductsCreatedForThisTests2 = this.GetOnlyProductsCreatedForThisTests( magentoService );
 
 			var updateSecondTimeQty = 100500;
-			var updateInventoryTask2 = magentoService.UpdateInventoryAsync( onlyProductsCreatedForThisTests2.ToInventory( x => updateSecondTimeQty ).ToList() );
+			var updateInventoryTask2 = magentoService.UpdateInventoryAsync( onlyProductsCreatedForThisTests2.ToInventory( x => updateSecondTimeQty ).ToList(), CancellationToken.None );
 			updateInventoryTask2.Wait();
 
 			//------------ Assert
@@ -49,7 +50,7 @@ namespace MagentoAccessTestsIntegration
 			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
 			//------------ Act
-			var getProductsTask = magentoService.GetProductsAsync( new[] { 0, 1 } );
+			var getProductsTask = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 } );
 			getProductsTask.Wait();
 
 			var allProductsinMagent = getProductsTask.Result.ToList();
@@ -57,12 +58,12 @@ namespace MagentoAccessTestsIntegration
 
 			var itemsToUpdate = onlyProductsCreatedForThisTests.Select( x => new InventoryBySku() { Sku = x.Sku, Qty = 123 } );
 
-			var updateInventoryTask = magentoService.UpdateInventoryBySkuAsync( itemsToUpdate, new[] { 0, 1 } );
+			var updateInventoryTask = magentoService.UpdateInventoryBySkuAsync( itemsToUpdate, CancellationToken.None, new[] { 0, 1 } );
 			updateInventoryTask.Wait();
 
 			/////
 
-			var getProductsTask2 = magentoService.GetProductsAsync( new[] { 0, 1 } );
+			var getProductsTask2 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 } );
 			getProductsTask2.Wait();
 
 			var allProductsinMagent2 = getProductsTask2.Result.ToList();
@@ -70,11 +71,11 @@ namespace MagentoAccessTestsIntegration
 
 			var itemsToUpdate2 = onlyProductsCreatedForThisTests2.Select( x => new InventoryBySku() { Sku = x.Sku, Qty = 100500 } );
 
-			var updateInventoryTask2 = magentoService.UpdateInventoryBySkuAsync( itemsToUpdate2, new[] { 0, 1 } );
+			var updateInventoryTask2 = magentoService.UpdateInventoryBySkuAsync( itemsToUpdate2, CancellationToken.None, new[] { 0, 1 } );
 			updateInventoryTask2.Wait();
 
 			//------------ Assert
-			var getProductsTask3 = magentoService.GetProductsAsync( new[] { 0, 1 } );
+			var getProductsTask3 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 } );
 			getProductsTask3.Wait();
 
 			var allProductsinMagent3 = getProductsTask3.Result.ToList();

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/DetermineMagentoVersion/CorrectCredentials.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/DetermineMagentoVersion/CorrectCredentials.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -36,7 +37,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.DetermineMagentoVers
 
 			// ------------ Act
 			magentoService.InitAsync( false ).Wait();
-			var getOrdersTask = magentoService.DetermineMagentoVersionAsync();
+			var getOrdersTask = magentoService.DetermineMagentoVersionAsync( CancellationToken.None );
 			getOrdersTask.Wait();
 
 			// ------------ Assert
@@ -71,7 +72,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.DetermineMagentoVers
 				ThrowExceptionIfFailed.AllItems );
 
 			// ------------ Act
-			var getOrdersTask = magentoService.DetermineMagentoVersionAndSetupServiceAsync();
+			var getOrdersTask = magentoService.DetermineMagentoVersionAndSetupServiceAsync( CancellationToken.None );
 			getOrdersTask.Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/DetermineMagentoVersion/InCorrectApiKey.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/DetermineMagentoVersion/InCorrectApiKey.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -20,7 +21,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.DetermineMagentoVers
 			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey + "_incorrectKey", "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, true, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
 			// ------------ Act
-			var getOrdersTask = magentoService.DetermineMagentoVersionAsync();
+			var getOrdersTask = magentoService.DetermineMagentoVersionAsync( CancellationToken.None );
 			getOrdersTask.Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/FillProductsDetails/GetProducsAndFillProductsDetails.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/FillProductsDetails/GetProducsAndFillProductsDetails.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccess.Misc;
@@ -22,10 +23,10 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.FillProductsDetails
 			var updatedFrom = DateTime.UtcNow.AddMonths( -15 );
 
 			// ------------ Act
-			var productsAsync = magentoService.GetProductsAsync( new[] { 0, 1 }, stockItemsOnly : false, updatedFrom : updatedFrom );
+			var productsAsync = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, stockItemsOnly : false, updatedFrom : updatedFrom );
 			productsAsync.Wait();
 
-			var fillProductsDetailsAsync = magentoService.FillProductsDetailsAsync( productsAsync.Result );
+			var fillProductsDetailsAsync = magentoService.FillProductsDetailsAsync( productsAsync.Result, CancellationToken.None );
 			fillProductsDetailsAsync.Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetOrders/UserAlreadyHasAccessTokens.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetOrders/UserAlreadyHasAccessTokens.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccess.Misc;
@@ -29,7 +30,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetOrders
 			// var modifiedTo = new DateTime( ( lastCreatedItem.UpdatedAt ).Ticks, DateTimeKind.Utc ).AddSeconds( -1 );
 			var modifiedFrom = new DateTime( 2018, 1, 28, 23, 23, 59 ).AddSeconds( 1 );
 			var modifiedTo = new DateTime( 2018, 2, 2, 23, 30, 39 ).AddSeconds( -1 );
-			var getOrdersTask = magentoService.GetOrdersAsync( modifiedFrom, modifiedTo, new Mark( "TEST-GET-ORDERS" ) );
+			var getOrdersTask = magentoService.GetOrdersAsync( modifiedFrom, modifiedTo, CancellationToken.None, new Mark( "TEST-GET-ORDERS" ) );
 			getOrdersTask.Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetOnlySpecialByTypeProducs.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetOnlySpecialByTypeProducs.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -22,8 +23,8 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetProductsAsync
 			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
 			// ------------ Act
-			var getProductsTask1 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : false, mark : new Mark( nameof( ReceiveProducts ) + "_s" ) );
-			var getProductsTask2 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, productType : "bundle", excludeProductByType : false, mark : new Mark( nameof( ReceiveProducts ) + "_b" ) );
+			var getProductsTask1 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : false, mark : new Mark( nameof( ReceiveProducts ) + "_s" ) );
+			var getProductsTask2 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, productType : "bundle", excludeProductByType : false, mark : new Mark( nameof( ReceiveProducts ) + "_b" ) );
 			Task.WhenAll( getProductsTask1, getProductsTask2 ).Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetProducsWithUpdateTimeAndSkusFilter.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetProducsWithUpdateTimeAndSkusFilter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccess.Misc;
@@ -22,11 +23,11 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetProductsAsync
 			var updatedFrom = DateTime.UtcNow.AddMonths( -7 );
 
 			// ------------ Act
-			var getProductsTask1 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, updatedFrom : updatedFrom );
+			var getProductsTask1 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, updatedFrom : updatedFrom );
 			getProductsTask1.Wait();
 			var expectedSku = getProductsTask1.Result.Take( 2 ).Select( x => x.Sku ).ToList();
 
-			var getProductsBySkusTask2 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, updatedFrom : updatedFrom, skus : expectedSku );
+			var getProductsBySkusTask2 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, updatedFrom : updatedFrom, skus : expectedSku );
 			getProductsBySkusTask2.Wait();
 			//------------Assert
 			getProductsTask1.Result.Should().NotBeNullOrEmpty();

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetProducsWithUpdateTimeFilter.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetProducsWithUpdateTimeFilter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -23,8 +24,8 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetProductsAsync
 			var updatedFrom = DateTime.UtcNow.AddMonths( -15 );
 
 			// ------------ Act
-			var getProductsTask1 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, updatedFrom : updatedFrom );
-			var getProductsTask2 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true );
+			var getProductsTask1 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, updatedFrom : updatedFrom );
+			var getProductsTask2 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true );
 			Task.WhenAll( getProductsTask1, getProductsTask2 ).Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetProductsWithoutSpecifiedType.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/GetProductsWithoutSpecifiedType.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -20,8 +21,8 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetProductsAsync
 			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
 			// ------------ Act
-			var getProductsTask1 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : true );
-			var getProductsTask2 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, productType : "bundle", excludeProductByType : true );
+			var getProductsTask1 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : true );
+			var getProductsTask2 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, productType : "bundle", excludeProductByType : true );
 			Task.WhenAll( getProductsTask1, getProductsTask2 ).Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/UserAlreadyHasAccessTokens.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetProductsAsync/UserAlreadyHasAccessTokens.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -19,7 +20,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetProductsAsync
 			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
 			// ------------ Act
-			var getProductsTask = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : false );
+			var getProductsTask = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : false );
 			getProductsTask.Wait();
 
 			// ------------ Assert

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetShipments/GetShipmentsTest.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/GetShipments/GetShipmentsTest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading;
+using FluentAssertions;
+using MagentoAccess;
+using MagentoAccess.Misc;
+using MagentoAccessTestsIntegration.TestEnvironment;
+using NUnit.Framework;
+
+namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetShipments
+{
+	[ TestFixture ]
+	[ Category( "ReadSmokeTests" ) ]
+	[ Parallelizable ]
+	internal class GetShipmentsTest : BaseTest
+	{
+		[ Test ]
+		[ TestCaseSource( typeof( GeneralTestCases ), "TestStoresCredentials" ) ]
+		public void ReceiveShipments( MagentoServiceCredentialsAndConfig credentials )
+		{
+			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
+
+			var shipments = magentoService.GetOrdersShipmentsAsync( DateTime.MinValue, DateTime.UtcNow, CancellationToken.None ).WaitResult();
+			shipments.Should().NotBeNull();
+			shipments.Count.Should().BeGreaterThan( 0 );
+			magentoService.IsRestAPIUsed.Should().Be( true );
+		}
+	}
+}

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/CorrectCredentialsAndUrl.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/CorrectCredentialsAndUrl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -17,12 +18,12 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.PingSoap
 		{
 			// ------------ Arrange
 			var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
-			magentoService.DetermineMagentoVersionAndSetupServiceAsync().GetAwaiter().GetResult();
+			magentoService.DetermineMagentoVersionAndSetupServiceAsync( CancellationToken.None ).GetAwaiter().GetResult();
 
 			// ------------ Act
 			Action act = () =>
 			{
-				var magentoInfoAsyncTask = magentoService.PingSoapAsync();
+				var magentoInfoAsyncTask = magentoService.PingSoapAsync( CancellationToken.None );
 				magentoInfoAsyncTask.Wait();
 			};
 

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/IncorrectApiKey.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/IncorrectApiKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -22,7 +23,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.PingSoap
 			{
 				var service = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, "incorrectKey", "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
-				var magentoInfoAsyncTask = service.PingSoapAsync();
+				var magentoInfoAsyncTask = service.PingSoapAsync( CancellationToken.None );
 				magentoInfoAsyncTask.Wait();
 			};
 

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/IncorrectApiUser.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/IncorrectApiUser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -23,7 +24,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.PingSoap
 			{
 				var service = this.CreateMagentoService( "incorrectuser", credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
-				var magentoInfoAsyncTask = service.PingSoapAsync();
+				var magentoInfoAsyncTask = service.PingSoapAsync( CancellationToken.None );
 				magentoInfoAsyncTask.Wait();
 			};
 

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/IncorrectUrl.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/PingSoap/IncorrectUrl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -22,7 +23,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.PingSoap
 			{
 				var service = this.CreateMagentoService( "incorrectuser", credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", "http://w.com", "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
 
-				var magentoInfoAsyncTask = service.PingSoapAsync();
+				var magentoInfoAsyncTask = service.PingSoapAsync( CancellationToken.None );
 				magentoInfoAsyncTask.Wait();
 			};
 

--- a/src/MagentoAccessTestsIntegration/MagentoServiceTests/UpdateInventory/GetOnlySpecialByTypeProducs.cs
+++ b/src/MagentoAccessTestsIntegration/MagentoServiceTests/UpdateInventory/GetOnlySpecialByTypeProducs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess;
@@ -30,7 +31,7 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetProductsAsync
 
 			// ------------ Act
 			//get products
-			var getProductsTask1 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : false, mark : new Mark( nameof( InventoryUpdated ) + "_s" ) );
+			var getProductsTask1 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : false, mark : new Mark( nameof( InventoryUpdated ) + "_s" ) );
 			Task.WhenAll( getProductsTask1 ).Wait();
 			var initialSkus = getProductsTask1.Result./*Where( x => x.Sku.Contains( "estSku1" ) ).*/ToList();
 			var src = initialSkus.ToInventory( x => ( int )x.Qty.ToDecimalOrDefault() );
@@ -38,11 +39,11 @@ namespace MagentoAccessTestsIntegration.MagentoServiceTests.GetProductsAsync
 			inventories.ForEach( x => x.Qty = val );
 
 			//update
-			var updateInventoryTask = magentoService.UpdateInventoryAsync( inventories );
+			var updateInventoryTask = magentoService.UpdateInventoryAsync( inventories, CancellationToken.None );
 			Task.WhenAll( updateInventoryTask ).Wait();
 
 			//get products
-			var getProductsTask3 = magentoService.GetProductsAsync( new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : false, mark : new Mark( nameof( InventoryUpdated ) + "_s" ) );
+			var getProductsTask3 = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 }, includeDetails : true, productType : "simple", excludeProductByType : false, mark : new Mark( nameof( InventoryUpdated ) + "_s" ) );
 			Task.WhenAll( getProductsTask3 ).Wait();
 			var resultSku = getProductsTask3.Result/*.Where( x => x.Sku.Contains( "estSku1" ) )*/;
 

--- a/src/MagentoAccessTestsIntegration/Services/Rest/v2x/MeagentoServiceLowLevelRestTest.cs
+++ b/src/MagentoAccessTestsIntegration/Services/Rest/v2x/MeagentoServiceLowLevelRestTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using MagentoAccess.Models.Services.Rest.v2x;
 using MagentoAccess.Services.Rest.v2x.WebRequester;
 using MagentoAccessTestsIntegration.TestEnvironment;
@@ -38,7 +39,7 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x
 				.Parameters( sc )
 				.Url( MagentoUrl.Create( "http://xxx" ) )
 				;
-			var res = qwe.RunAsync();
+			var res = qwe.RunAsync( CancellationToken.None );
 			res.Wait();
 		}
 

--- a/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/CatalogStockItemsRepositoryTest.cs
+++ b/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/CatalogStockItemsRepositoryTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess.Misc;
@@ -14,25 +15,27 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 	[ TestFixture ]
 	internal class CatalogStockItemsRepositoryTest : BaseTest
 	{
+		private MagentoTimeouts _defaultOperationsTimeouts = new MagentoTimeouts();
+
 		[ Test ]
 		[ TestCaseSource( typeof( RepositoryTestCases ), "TestCases" ) ]
 		[ Ignore( "Because there is multiple update tests" ) ]
 		public void PutStockItemAsync_StoreContainsProducts_ProductsUpdated( RepositoryTestCase testCase )
 		{
 			//------------ Arrange
-			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url );
-			var token = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass ).WaitResult();
-			var productRepository = new ProductRepository( token, testCase.Url );
-			var stockRepository = new CatalogStockItemRepository( token, testCase.Url );
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, _defaultOperationsTimeouts );
+			var token = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
+			var productRepository = new ProductRepository( token, testCase.Url, _defaultOperationsTimeouts );
+			var stockRepository = new CatalogStockItemRepository( token, testCase.Url, _defaultOperationsTimeouts );
 
-			var products = productRepository.GetProductsAsync( DateTime.MinValue, new PagingModel( 5, 1 ) ).WaitResult();
-			var stockItem = stockRepository.GetStockItemAsync( products.items.First().sku ).WaitResult();
+			var products = productRepository.GetProductsAsync( DateTime.MinValue, new PagingModel( 5, 1 ), CancellationToken.None ).WaitResult();
+			var stockItem = stockRepository.GetStockItemAsync( products.items.First().sku, CancellationToken.None ).WaitResult();
 			//------------ Act
-			var stockItem2 = stockRepository.PutStockItemAsync( products.items.First().sku, stockItem.itemId.Value.ToString(), new RootObject { stockItem = new StockItem { qty = 100, isInStock = true } } ).WaitResult();
-			var stockItem2Updated = stockRepository.GetStockItemAsync( products.items.First().sku ).WaitResult();
+			var stockItem2 = stockRepository.PutStockItemAsync( products.items.First().sku, stockItem.itemId.Value.ToString(), new RootObject { stockItem = new StockItem { qty = 100, isInStock = true } }, CancellationToken.None ).WaitResult();
+			var stockItem2Updated = stockRepository.GetStockItemAsync( products.items.First().sku, CancellationToken.None ).WaitResult();
 
-			var stockItem3 = stockRepository.PutStockItemAsync( products.items.First().sku, stockItem.itemId.Value.ToString(), new RootObject { stockItem = new StockItem { qty = 100500, isInStock = false } } ).WaitResult();
-			var stockItem3Updated = stockRepository.GetStockItemAsync( products.items.First().sku ).WaitResult();
+			var stockItem3 = stockRepository.PutStockItemAsync( products.items.First().sku, stockItem.itemId.Value.ToString(), new RootObject { stockItem = new StockItem { qty = 100500, isInStock = false } }, CancellationToken.None ).WaitResult();
+			var stockItem3Updated = stockRepository.GetStockItemAsync( products.items.First().sku, CancellationToken.None ).WaitResult();
 			//------------ Assert
 			stockItem2.Should().Be( true );
 			stockItem3.Should().Be( true );
@@ -48,19 +51,19 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		public void PutStockItemsAsync_StoreContainsProducts_ProductsUpdated( RepositoryTestCase testCase )
 		{
 			//------------ Arrange
-			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url );
-			var token = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass ).WaitResult();
-			var productRepository = new ProductRepository( token, testCase.Url );
-			var stockRepository = new CatalogStockItemRepository( token, testCase.Url );
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, _defaultOperationsTimeouts );
+			var token = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
+			var productRepository = new ProductRepository( token, testCase.Url, _defaultOperationsTimeouts );
+			var stockRepository = new CatalogStockItemRepository( token, testCase.Url, _defaultOperationsTimeouts );
 
-			var products = productRepository.GetProductsAsync( DateTime.MinValue, "simple", new PagingModel( 5, 1 ) ).WaitResult();
-			var stockItems = stockRepository.GetStockItemsAsync( products.items.Select( x => x.sku ) ).WaitResult();
+			var products = productRepository.GetProductsAsync( DateTime.MinValue, "simple", new PagingModel( 5, 1 ), CancellationToken.None ).WaitResult();
+			var stockItems = stockRepository.GetStockItemsAsync( products.items.Select( x => x.sku ), CancellationToken.None ).WaitResult();
 			//------------ Act
-			var stockItem2 = stockRepository.PutStockItemsAsync( products.items.Select( x => Tuple.Create( x.sku, x.id.ToString(), new RootObject { stockItem = new StockItem { qty = 100, isInStock = true } } ) ) ).WaitResult();
-			var stockItem2Updated = stockRepository.GetStockItemsAsync( products.items.Select( x => x.sku ) ).WaitResult();
+			var stockItem2 = stockRepository.PutStockItemsAsync( products.items.Select( x => Tuple.Create( x.sku, x.id.ToString(), new RootObject { stockItem = new StockItem { qty = 100, isInStock = true } } ) ), CancellationToken.None ).WaitResult();
+			var stockItem2Updated = stockRepository.GetStockItemsAsync( products.items.Select( x => x.sku ), CancellationToken.None ).WaitResult();
 
-			var stockItem3 = stockRepository.PutStockItemsAsync( products.items.Select( x => Tuple.Create( x.sku, x.id.ToString(), new RootObject { stockItem = new StockItem { qty = 100500, isInStock = false } } ) ) ).WaitResult();
-			var stockItem3Updated = stockRepository.GetStockItemsAsync( products.items.Select( x => x.sku ) ).WaitResult();
+			var stockItem3 = stockRepository.PutStockItemsAsync( products.items.Select( x => Tuple.Create( x.sku, x.id.ToString(), new RootObject { stockItem = new StockItem { qty = 100500, isInStock = false } } ) ), CancellationToken.None ).WaitResult();
+			var stockItem3Updated = stockRepository.GetStockItemsAsync( products.items.Select( x => x.sku ), CancellationToken.None ).WaitResult();
 			//------------ Assert
 			stockItem2.Should().OnlyContain( x => x );
 			stockItem3.Should().OnlyContain( x => x );

--- a/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/ProductRepositoryTest.cs
+++ b/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/ProductRepositoryTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using MagentoAccess.Misc;
 using MagentoAccess.Services.Rest.v2x.Repository;
@@ -14,10 +15,12 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 	[ Category( "v2LowLevelReadSmoke" ) ]
 	internal class ProductRepositoryTest
 	{
+		private MagentoTimeouts _defaultOperationsTimeouts = new MagentoTimeouts();
+
 		private static AuthorizationToken GetToken( RepositoryTestCase testCase )
 		{
-			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url );
-			return adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass ).WaitResult();
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, new MagentoTimeouts() );
+			return adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
 		}
 
 		[ Test ]
@@ -26,10 +29,10 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		{
 			//------------ Arrange
 			var token = GetToken( testCase );
-			var productRepository = new ProductRepository( token, testCase.Url );
+			var productRepository = new ProductRepository( token, testCase.Url, _defaultOperationsTimeouts );
 
 			//------------ Act
-			var products = productRepository.GetProductsAsync().WaitResult();
+			var products = productRepository.GetProductsAsync( CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			token.Token.Should().NotBeNullOrWhiteSpace();
@@ -43,13 +46,13 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		{
 			//------------ Arrange
 			var token = GetToken( testCase );
-			var productRepository = new ProductRepository( token, testCase.Url );
-			var products = productRepository.GetProductsAsync().WaitResult();
+			var productRepository = new ProductRepository( token, testCase.Url, _defaultOperationsTimeouts );
+			var products = productRepository.GetProductsAsync( CancellationToken.None ).WaitResult();
 			var allproductsSortedByDate = products.SelectMany( x => x.items ).OrderBy( y => y.updatedAt );
 			var date = allproductsSortedByDate.Skip( allproductsSortedByDate.Count() / 2 ).First().updatedAt;
 
 			//------------ Act
-			var productsUpdatedAt = productRepository.GetProductsAsync( date.ToDateTimeOrDefault() ).WaitResult();
+			var productsUpdatedAt = productRepository.GetProductsAsync( date.ToDateTimeOrDefault(), CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			token.Token.Should().NotBeNullOrWhiteSpace();
@@ -64,11 +67,11 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		{
 			//------------ Arrange
 			var token = GetToken( testCase );
-			var productRepository = new ProductRepository( token, testCase.Url );
+			var productRepository = new ProductRepository( token, testCase.Url, _defaultOperationsTimeouts );
 
 			//------------ Act
-			var simpleProducts = productRepository.GetProductsAsync( DateTime.MinValue, "simple" ).WaitResult();
-			var bundleProducts = productRepository.GetProductsAsync( DateTime.MinValue, "bundle" ).WaitResult();
+			var simpleProducts = productRepository.GetProductsAsync( DateTime.MinValue, "simple", CancellationToken.None ).WaitResult();
+			var bundleProducts = productRepository.GetProductsAsync( DateTime.MinValue, "bundle", CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			token.Token.Should().NotBeNullOrWhiteSpace();
@@ -84,10 +87,10 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		{
 			//------------ Arrange
 			var token = GetToken( testCase );
-			var productRepository = new ProductRepository( token, testCase.Url );
+			var productRepository = new ProductRepository( token, testCase.Url, _defaultOperationsTimeouts );
 
 			//------------ Act
-			var productPages = productRepository.GetProductsAsync( DateTime.MinValue, null, false ).WaitResult();
+			var productPages = productRepository.GetProductsAsync( DateTime.MinValue, null, false, CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			token.Token.Should().NotBeNullOrWhiteSpace();
@@ -101,10 +104,10 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		{
 			//------------ Arrange
 			var token = GetToken( testCase );
-			var productRepository = new ProductRepository( token, testCase.Url );
+			var productRepository = new ProductRepository( token, testCase.Url, _defaultOperationsTimeouts );
 
 			//------------ Act
-			var productsManufacturers = productRepository.GetManufacturersAsync().WaitResult();
+			var productsManufacturers = productRepository.GetManufacturersAsync( CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			token.Token.Should().NotBeNullOrWhiteSpace();
@@ -116,11 +119,11 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		[ TestCaseSource( typeof( RepositoryTestCases ), "TestCases" ) ]
 		public void GetProductsBySkusAsync( RepositoryTestCase testCase )
 		{
-			var productRepository = new ProductRepository( GetToken( testCase ), testCase.Url );
+			var productRepository = new ProductRepository( GetToken( testCase ), testCase.Url, _defaultOperationsTimeouts );
 			var skus = new List< string >{ "testsku1", "testsku2" };
 			const int batchesCount = 1;
 
-			var result = productRepository.GetProductsBySkusAsync( skus, Mark.Blank() ).Result.ToList();
+			var result = productRepository.GetProductsBySkusAsync( skus, CancellationToken.None, Mark.Blank() ).Result.ToList();
 
 			result.Count.Should().Be( batchesCount );
 			result.First().items.Count.Should().Be( skus.Count );

--- a/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/SaleRepositoryTest.cs
+++ b/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/SaleRepositoryTest.cs
@@ -93,6 +93,20 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 
 		[ Test ]
 		[ TestCaseSource( typeof( RepositoryTestCases ), "TestCases" ) ]
+		public void GetOrdersShipmentsAsync_StoreContainsShipments_ReceiveModifiedShipments( RepositoryTestCase credentials )
+		{
+			var adminRepository = new IntegrationAdminTokenRepository( credentials.Url, _defaultOperationsTimeouts );
+			var token = adminRepository.GetTokenAsync( credentials.MagentoLogin, credentials.MagentoPass, CancellationToken.None ).WaitResult();
+			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( token, credentials.Url, _defaultOperationsTimeouts );
+
+			var page = new PagingModel( 100, 1 );
+			var shipments = salesOrderRepositoryV1.GetOrdersShipmentsAsync( DateTime.MinValue, DateTime.UtcNow, page, CancellationToken.None ).WaitResult();
+
+			shipments.Items.Should().NotBeNullOrEmpty();
+		}
+
+		[ Test ]
+		[ TestCaseSource( typeof( RepositoryTestCases ), "TestCases" ) ]
 		public void GivenTooSmallTimeout_WhenGetOrdersAsyncIsCalled_ThenTimeoutExceptionIsExcepted( RepositoryTestCase testCase )
 		{
 			var specificTimeouts = new MagentoTimeouts();

--- a/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/SaleRepositoryTest.cs
+++ b/src/MagentoAccessTestsIntegration/Services/Rest/v2x/Repository/SaleRepositoryTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using MagentoAccess.Misc;
 using MagentoAccess.Services.Rest.v2x;
@@ -12,18 +14,20 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 	[ Category( "v2LowLevelReadSmoke" ) ]
 	internal class SaleRepositoryTest
 	{
+		private MagentoTimeouts _defaultOperationsTimeouts = new MagentoTimeouts();
+
 		[ Test ]
 		[ TestCaseSource( typeof( RepositoryTestCases ), "TestCases" ) ]
 		public void GetOrdersAsync_StoreContainsOrders_ReceivPage( RepositoryTestCase testCase )
 		{
 			//------------ Arrange
-			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url );
-			var token = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass ).WaitResult();
-			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( token, testCase.Url );
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, _defaultOperationsTimeouts );
+			var token = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
+			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( token, testCase.Url, _defaultOperationsTimeouts );
 			var itemsPerPage = 5;
 
 			//------------ Act
-			var orders = salesOrderRepositoryV1.GetOrdersAsync( new DateTime( 2012, 1, 1 ), DateTime.UtcNow.AddDays( 1 ), new PagingModel( itemsPerPage, 1 ) ).WaitResult();
+			var orders = salesOrderRepositoryV1.GetOrdersAsync( new DateTime( 2012, 1, 1 ), DateTime.UtcNow.AddDays( 1 ), new PagingModel( itemsPerPage, 1 ), CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			token.Token.Should().NotBeNullOrWhiteSpace();
@@ -36,12 +40,12 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		public void GetOrdersAsync_StoreContainsOrders_ReceiveOrders( RepositoryTestCase testCase )
 		{
 			//------------ Arrange
-			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url );
-			var tokenTask = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass ).WaitResult();
-			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( tokenTask, testCase.Url );
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, _defaultOperationsTimeouts );
+			var tokenTask = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
+			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( tokenTask, testCase.Url, _defaultOperationsTimeouts );
 
 			//------------ Act
-			var items = salesOrderRepositoryV1.GetOrdersAsync( DateTime.MinValue, DateTime.UtcNow ).WaitResult();
+			var items = salesOrderRepositoryV1.GetOrdersAsync( DateTime.MinValue, DateTime.UtcNow, CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			tokenTask.Token.Should().NotBeNullOrWhiteSpace();
@@ -53,14 +57,14 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		public void GetOrdersAsync_StoreContainsOrders_ReceiveOrdersByIdReceivePage( RepositoryTestCase testCase )
 		{
 			//------------ Arrange
-			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url );
-			var tokenTask = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass ).WaitResult();
-			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( tokenTask, testCase.Url );
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, _defaultOperationsTimeouts );
+			var tokenTask = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
+			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( tokenTask, testCase.Url, _defaultOperationsTimeouts );
 			var itemsPerPage = 5;
 
 			//------------ Act
-			var items = salesOrderRepositoryV1.GetOrdersAsync( DateTime.MinValue, DateTime.UtcNow, new PagingModel( itemsPerPage, 1 ) ).WaitResult();
-			var items2 = salesOrderRepositoryV1.GetOrdersAsync( items.items.Select( x => x.increment_id ), new PagingModel( itemsPerPage, 1 ) ).WaitResult();
+			var items = salesOrderRepositoryV1.GetOrdersAsync( DateTime.MinValue, DateTime.UtcNow, new PagingModel( itemsPerPage, 1 ), CancellationToken.None ).WaitResult();
+			var items2 = salesOrderRepositoryV1.GetOrdersAsync( items.items.Select( x => x.increment_id ), new PagingModel( itemsPerPage, 1 ), CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			tokenTask.Token.Should().NotBeNullOrWhiteSpace();
@@ -73,18 +77,40 @@ namespace MagentoAccessTestsIntegration.Services.Rest.v2x.Repository
 		public void GetOrdersAsync_StoreContainsOrders_ReceiveOrdersByIdReceive( RepositoryTestCase testCase )
 		{
 			//------------ Arrange
-			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url );
-			var tokenTask = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass ).WaitResult();
-			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( tokenTask, testCase.Url );
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, _defaultOperationsTimeouts );
+			var tokenTask = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
+			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( tokenTask, testCase.Url, _defaultOperationsTimeouts );
 
 			//------------ Act
-			var items = salesOrderRepositoryV1.GetOrdersAsync( DateTime.MinValue, DateTime.UtcNow ).WaitResult();
-			var items2 = salesOrderRepositoryV1.GetOrdersAsync( items.SelectMany( y => y.items ).Select( x => x.increment_id ) ).WaitResult();
+			var items = salesOrderRepositoryV1.GetOrdersAsync( DateTime.MinValue, DateTime.UtcNow, CancellationToken.None ).WaitResult();
+			var items2 = salesOrderRepositoryV1.GetOrdersAsync( items.SelectMany( y => y.items ).Select( x => x.increment_id ), CancellationToken.None ).WaitResult();
 
 			//------------ Assert
 			tokenTask.Token.Should().NotBeNullOrWhiteSpace();
 			items2.SelectMany( y => y.items ).Count().Should().BeGreaterOrEqualTo( 1 );
 			items2.SelectMany( y => y.items ).Count().Should().Be( items.SelectMany( y => y.items ).Count() );
+		}
+
+		[ Test ]
+		[ TestCaseSource( typeof( RepositoryTestCases ), "TestCases" ) ]
+		public void GivenTooSmallTimeout_WhenGetOrdersAsyncIsCalled_ThenTimeoutExceptionIsExcepted( RepositoryTestCase testCase )
+		{
+			var specificTimeouts = new MagentoTimeouts();
+			specificTimeouts.Set( MagentoOperationEnum.GetModifiedOrders, new MagentoOperationTimeout( 10 ) );
+
+			var adminRepository = new IntegrationAdminTokenRepository( testCase.Url, specificTimeouts );
+			var tokenTask = adminRepository.GetTokenAsync( testCase.MagentoLogin, testCase.MagentoPass, CancellationToken.None ).WaitResult();
+			var salesOrderRepositoryV1 = new SalesOrderRepositoryV1( tokenTask, testCase.Url, specificTimeouts );
+
+			var ex = Assert.Throws< AggregateException >( () =>
+			{
+				var items = salesOrderRepositoryV1.GetOrdersAsync( DateTime.MinValue, DateTime.UtcNow, CancellationToken.None ).WaitResult();
+				var items2 = salesOrderRepositoryV1.GetOrdersAsync( items.SelectMany( y => y.items ).Select( x => x.increment_id ), CancellationToken.None ).WaitResult();
+			} );
+
+			ex.Should().NotBeNull();
+			ex.InnerException.Should().NotBeNull();
+			ex.InnerException.GetType().Should().Be( typeof( TaskCanceledException ) );
 		}
 	}
 }

--- a/src/MagentoAccessTestsIntegration/TestEnvironment/BaseTest.cs
+++ b/src/MagentoAccessTestsIntegration/TestEnvironment/BaseTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DotNetOpenAuth.Messaging;
 using MagentoAccess;
@@ -39,7 +40,7 @@ namespace MagentoAccessTestsIntegration.TestEnvironment
 				getProductsMaxThreads,
 				sessionLifeTime,
 				true
-			), new MagentoConfig() { VersionByDefault = magentoVersionByDefault, OnUpdateInventory = onUpdateInventory, UseVersionByDefaultOnly = useDefaultVersionOnly} );
+			), new MagentoConfig() { VersionByDefault = magentoVersionByDefault, OnUpdateInventory = onUpdateInventory, UseVersionByDefaultOnly = useDefaultVersionOnly }, new MagentoTimeouts() );
 			magentoService.InitAsync( supressExc ).Wait();
 			return magentoService;
 		}
@@ -92,10 +93,10 @@ namespace MagentoAccessTestsIntegration.TestEnvironment
 						false, 
 						credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems 
 						);
-					var creationResult = magentoService.CreateOrderAsync( ordersModels );
+					var creationResult = magentoService.CreateOrderAsync( ordersModels, CancellationToken.None );
 					creationResult.Wait();
 					var ordersIds = creationResult.Result.Select( x => x.OrderId ).ToList();
-					var ordersTask = magentoService.GetOrdersAsync( ordersIds );
+					var ordersTask = magentoService.GetOrdersAsync( ordersIds, CancellationToken.None );
 					ordersTask.Wait();
 
 					if( this._orders == null )
@@ -140,7 +141,7 @@ namespace MagentoAccessTestsIntegration.TestEnvironment
 							source.Add( new CreateProductModel( "0", sku, name, 1, i == 4 ? "bundle" : "simple" ) );
 						}
 						var magentoService = this.CreateMagentoService( credentials.AuthenticatedUserCredentials.SoapApiUser, credentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", credentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", credentials.Config.VersionByDefault, credentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, credentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, credentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
-						var creationResult = magentoService.CreateProductAsync( source );
+						var creationResult = magentoService.CreateProductAsync( source, CancellationToken.None );
 
 						creationResult.Wait();
 						this._productsIds[ credentials.AuthenticatedUserCredentials.SoapApiKey ] = new Dictionary< int, string >();
@@ -177,7 +178,7 @@ namespace MagentoAccessTestsIntegration.TestEnvironment
 					var productsToRemove = this.GetOnlyProductsCreatedForThisTests( magentoService );
 					var productsToRemoveDeleteProductModels = productsToRemove.Select( p => new DeleteProductModel( "0", 0, p.ProductId, "" ) ).ToList();
 
-					var deleteres = magentoService.DeleteProductAsync( productsToRemoveDeleteProductModels );
+					var deleteres = magentoService.DeleteProductAsync( productsToRemoveDeleteProductModels, CancellationToken.None );
 
 					deleteres.Wait();
 				}
@@ -191,7 +192,7 @@ namespace MagentoAccessTestsIntegration.TestEnvironment
 		protected IEnumerable< Product > GetOnlyProductsCreatedForThisTests( MagentoServiceCredentialsAndConfig magentoServiceSoapCredentials )
 		{
 			var magentoService = this.CreateMagentoService(magentoServiceSoapCredentials.AuthenticatedUserCredentials.SoapApiUser, magentoServiceSoapCredentials.AuthenticatedUserCredentials.SoapApiKey, "null", "null", "null", "null", magentoServiceSoapCredentials.AuthenticatedUserCredentials.BaseMagentoUrl, "http://w.com", "http://w.com", "http://w.com", MagentoVersions.M_2_0_2_0, magentoServiceSoapCredentials.AuthenticatedUserCredentials.GetProductsThreadsLimit, magentoServiceSoapCredentials.AuthenticatedUserCredentials.SessionLifeTimeMs, false, magentoServiceSoapCredentials.Config.UseVersionByDefaultOnly, ThrowExceptionIfFailed.AllItems );
-			var getProductsTask = magentoService.GetProductsAsync( new[] { 0, 1 } );
+			var getProductsTask = magentoService.GetProductsAsync( CancellationToken.None, new[] { 0, 1 } );
 			getProductsTask.Wait();
 
 			var allProductsinMagent = getProductsTask.Result.ToList();
@@ -201,7 +202,7 @@ namespace MagentoAccessTestsIntegration.TestEnvironment
 
 		protected IEnumerable< Product > GetOnlyProductsCreatedForThisTests( IMagentoService service )
 		{
-			var getProductsTask = service.GetProductsAsync( new[] { 0, 1 } );
+			var getProductsTask = service.GetProductsAsync( CancellationToken.None, new[] { 0, 1 } );
 			getProductsTask.Wait();
 
 			var allProductsinMagent = getProductsTask.Result.ToList();


### PR DESCRIPTION
Zoey order items are no longer being returned in the "items" collection. Now they're in order_invoices.
- Get order_invoices, order_shipments from the Zoey api for each order; map order_invoices to order items; added tests for new code
- Handle order.Items = null; extracted the mapping of order items into a method and added tests; corrected a typo

This branch is based on [GUARD-848/GUARD-811](https://github.com/skuvault/magentoAccess/tree/GUARD-848-GUARD-811-Configurable-Timeouts-Server-Unavailable-Errors-Fixes).

To see just this branch's changes, here's a branch compare - https://github.com/skuvault/magentoAccess/compare/GUARD-848-GUARD-811-Configurable-Timeouts-Server-Unavailable-Errors-Fixes...GUARD-1724-Zoey-Orders-Sync-Error