### PR TITLE
2021-02-19 GUARD-1724 Zoey Orders Sync Error RELOADED

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.18.0.0" ) ]
+[ assembly : AssemblyVersion( "2.18.2.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "MagentoAccess" ) ]
 [ assembly : AssemblyCompany( "SkuVault Inc." ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2020 SkuVault Inc." ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2021 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "Magento webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.15.4.0" ) ]
+[ assembly : AssemblyVersion( "2.18.0.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.18.3.0" ) ]
+[ assembly : AssemblyVersion( "2.18.4.0" ) ]

--- a/src/MagentoAccess/Misc/MagentoTimeouts.cs
+++ b/src/MagentoAccess/Misc/MagentoTimeouts.cs
@@ -99,7 +99,8 @@ namespace MagentoAccess.Misc
 		{
 			get
 			{
-				if ( _timeouts.TryGetValue( operation, out MagentoOperationTimeout timeout ) )
+				MagentoOperationTimeout timeout;
+				if ( _timeouts.TryGetValue( operation, out timeout ) )
 					return timeout.TimeoutInMs;
 
 				return DefaultOperationTimeout.TimeoutInMs;

--- a/src/MagentoAccess/Models/GetOrders/Item.cs
+++ b/src/MagentoAccess/Models/GetOrders/Item.cs
@@ -22,7 +22,7 @@ namespace MagentoAccess.Models.GetOrders
 		public decimal TaxPercent { get; set; }
 		public decimal TaxAmount { get; set; }
 		public decimal BaseTaxAmount { get; set; }
-		public decimal DscountAmount { get; set; }
+		public decimal DiscountAmount { get; set; }
 		public decimal BaseDiscountAmount { get; set; }
 		public decimal RowTotal { get; set; }
 		public decimal BaseRowTotal { get; set; }
@@ -64,7 +64,7 @@ namespace MagentoAccess.Models.GetOrders
 			          && Equals( this.TaxPercent, item.TaxPercent )
 			          && Equals( this.TaxAmount, item.TaxAmount )
 			          && Equals( this.BaseTaxAmount, item.BaseTaxAmount )
-			          && Equals( this.DscountAmount, item.DscountAmount )
+			          && Equals( this.DiscountAmount, item.DiscountAmount )
 			          && Equals( this.BaseDiscountAmount, item.BaseDiscountAmount )
 			          && Equals( this.RowTotal, item.RowTotal )
 			          && Equals( this.BaseRowTotal, item.BaseRowTotal )

--- a/src/MagentoAccess/Models/GetOrders/Order.cs
+++ b/src/MagentoAccess/Models/GetOrders/Order.cs
@@ -107,30 +107,7 @@ namespace MagentoAccess.Models.GetOrders
 			this.GrandTotal = order.GrandTotal.ToDecimalOrDefault();
 			this.OrderIncrementalId = order.IncrementId;
 			this.OrderId = order.OrderId;
-			this.Items = order.Items.Select( x => new Item
-				{
-					BaseDiscountAmount = x.BaseDiscountAmount.ToDecimalOrDefault(),
-					BaseOriginalPrice = x.BaseOriginalPrice.ToDecimalOrDefault(),
-					Sku = x.Sku,
-					Name = x.Name,
-					BaseTaxAmount = x.BaseTaxAmount.ToDecimalOrDefault(),
-					ItemId = x.ItemId,
-					BasePrice = x.BasePrice.ToDecimalOrDefault(),
-					BaseRowTotal = x.BaseRowTotal.ToDecimalOrDefault(),
-					DscountAmount = x.DiscountAmount.ToDecimalOrDefault(),
-					OriginalPrice = x.OriginalPrice.ToDecimalOrDefault(),
-					Price = x.Price.ToDecimalOrDefault(),
-					ProductType = x.ProductType,
-					QtyCanceled = x.QtyCanceled.ToDecimalOrDefault(),
-					QtyInvoiced = x.QtyInvoiced.ToDecimalOrDefault(),
-					QtyOrdered = x.QtyOrdered.ToDecimalOrDefault(),
-					QtyShipped = x.QtyShipped.ToDecimalOrDefault(),
-					QtyRefunded = x.QtyRefunded.ToDecimalOrDefault(),
-					RowTotal = x.RowTotal.ToDecimalOrDefault(),
-					TaxAmount = x.TaxAmount.ToDecimalOrDefault(),
-					TaxPercent = x.TaxPercent.ToDecimalOrDefault(),
-				}
-			).ToList();
+			this.Items = order.Items.ToSvOrderItems().ToList();
 			this.PaymentMethod = order.Payment?.Method;
 			this.StoreName = order.StoreName;
 			this.Subtotal = order.Subtotal.ToDecimalOrDefault();
@@ -212,7 +189,7 @@ namespace MagentoAccess.Models.GetOrders
 					ItemId = x.item_id,
 					BasePrice = x.base_price.ToDecimalOrDefault(),
 					BaseRowTotal = x.base_row_total.ToDecimalOrDefault(),
-					DscountAmount = x.discount_amount.ToDecimalOrDefault(),
+					DiscountAmount = x.discount_amount.ToDecimalOrDefault(),
 					OriginalPrice = x.original_price.ToDecimalOrDefault(),
 					Price = x.price.ToDecimalOrDefault(),
 					ProductType = x.product_type,
@@ -453,6 +430,36 @@ namespace MagentoAccess.Models.GetOrders
 			var conntinueFlag = true;
 			conntinueFlag = o1Sorted.SequenceEqual( o2Sorted );
 			return conntinueFlag;
+		}
+
+		internal static IEnumerable< Item > ToSvOrderItems( this IEnumerable< OrderItemEntity > items )
+		{
+			if ( items == null )
+				return new List< Item >();
+			return items.Select( x => new Item
+				{
+					BaseDiscountAmount = x.BaseDiscountAmount.ToDecimalOrDefault(),
+					BaseOriginalPrice = x.BaseOriginalPrice.ToDecimalOrDefault(),
+					Sku = x.Sku,
+					Name = x.Name,
+					BaseTaxAmount = x.BaseTaxAmount.ToDecimalOrDefault(),
+					ItemId = x.ItemId,
+					BasePrice = x.BasePrice.ToDecimalOrDefault(),
+					BaseRowTotal = x.BaseRowTotal.ToDecimalOrDefault(),
+					DiscountAmount = x.DiscountAmount.ToDecimalOrDefault(),
+					OriginalPrice = x.OriginalPrice.ToDecimalOrDefault(),
+					Price = x.Price.ToDecimalOrDefault(),
+					ProductType = x.ProductType,
+					QtyCanceled = x.QtyCanceled.ToDecimalOrDefault(),
+					QtyInvoiced = x.QtyInvoiced.ToDecimalOrDefault(),
+					QtyOrdered = x.QtyOrdered.ToDecimalOrDefault(),
+					QtyShipped = x.QtyShipped.ToDecimalOrDefault(),
+					QtyRefunded = x.QtyRefunded.ToDecimalOrDefault(),
+					RowTotal = x.RowTotal.ToDecimalOrDefault(),
+					TaxAmount = x.TaxAmount.ToDecimalOrDefault(),
+					TaxPercent = x.TaxPercent.ToDecimalOrDefault()
+				}
+			);
 		}
 	}
 }

--- a/src/MagentoAccess/Models/Services/SOAP/GetOrders/OrderInfoResponse.cs
+++ b/src/MagentoAccess/Models/Services/SOAP/GetOrders/OrderInfoResponse.cs
@@ -1019,7 +1019,7 @@ namespace MagentoAccess.Models.Services.Soap.GetOrders
 		public string Weight { get; private set; }
 	}
 
-	internal class OrderItemEntity
+	public class OrderItemEntity
 	{
 		public OrderItemEntity( )
 		{
@@ -1333,6 +1333,15 @@ namespace MagentoAccess.Models.Services.Soap.GetOrders
 		public OrderItemEntity( TsZoey_v_1_9_0_1_CE.salesOrderItemEntity salesOrderItemEntity )
 		{
 			Mapper.Map< TsZoey_v_1_9_0_1_CE.salesOrderItemEntity, OrderItemEntity >( salesOrderItemEntity, this );
+		}
+
+		public OrderItemEntity( TsZoey_v_1_9_0_1_CE.salesOrderInvoiceItemEntity salesOrderInvoiceItemEntity, string discountAmount )
+		{
+			this.Price = salesOrderInvoiceItemEntity.price;
+			this.QtyOrdered = salesOrderInvoiceItemEntity.qty;
+			this.Sku = salesOrderInvoiceItemEntity.sku;
+			this.DiscountAmount = discountAmount;
+			this.TaxAmount = salesOrderInvoiceItemEntity.tax_amount;
 		}
 
 		public string OrderId { get; set; }

--- a/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Magento.wsdl
+++ b/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Magento.wsdl
@@ -2590,6 +2590,8 @@
           <xsd:element minOccurs="0" name="telephone" type="xsd:string" />
           <xsd:element minOccurs="0" name="postcode" type="xsd:string" />
           <xsd:element minOccurs="0" name="zoey_order_comment" type="xsd:string" />
+          <xsd:element minOccurs="0" name="order_invoices" type="typens:salesOrderInvoiceEntityArray" />
+          <xsd:element minOccurs="0" name="order_shipments" type="typens:salesOrderShipmentEntityArray" />
         </xsd:sequence>
       </xsd:complexType>
       <xsd:complexType name="salesOrderListEntityArray">

--- a/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Reference.cs
+++ b/src/MagentoAccess/Service References/TsZoey_v_1_9_0_1_CE/Reference.cs
@@ -15100,6 +15100,10 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
         
         private string zoey_order_commentField;
         
+        private salesOrderInvoiceEntity[] order_invoicesField;
+        
+        private salesOrderShipmentEntity[] order_shipmentsField;
+        
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=0)]
         public string increment_id {
@@ -17153,7 +17157,7 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
         }
         
         /// <remarks/>
-        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=171)]
+        [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=172)]
         public string zoey_order_comment {
             get {
                 return this.zoey_order_commentField;
@@ -17161,6 +17165,32 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
             set {
                 this.zoey_order_commentField = value;
                 this.RaisePropertyChanged("zoey_order_comment");
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=176)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("complexObjectArray", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, IsNullable=false)]
+        public salesOrderInvoiceEntity[] order_invoices {
+            get {
+                return this.order_invoicesField;
+            }
+            set {
+                this.order_invoicesField = value;
+                this.RaisePropertyChanged("order_invoices");
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlArrayAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=177)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("complexObjectArray", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, IsNullable=false)]
+        public salesOrderShipmentEntity[] order_shipments {
+            get {
+                return this.order_shipmentsField;
+            }
+            set {
+                this.order_shipmentsField = value;
+                this.RaisePropertyChanged("order_shipments");
             }
         }
         
@@ -18869,7 +18899,7 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
         private salesOrderStatusHistoryEntity[] status_historyField;
         
         private string zoey_order_commentField;
-        
+
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified, Order=0)]
         public string increment_id {
@@ -19747,7 +19777,7 @@ namespace MagentoAccess.TsZoey_v_1_9_0_1_CE {
                 this.RaisePropertyChanged("zoey_order_comment");
             }
         }
-        
+               
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
         
         protected void RaisePropertyChanged(string propertyName) {

--- a/src/MagentoAccessTests/MagentoAccessTests.csproj
+++ b/src/MagentoAccessTests/MagentoAccessTests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Misc\ExtensionsTest.cs" />
     <Compile Include="Misc\MagentoServiceFactoryTest.cs" />
     <Compile Include="Misc\MagentoTimeoutsTests.cs" />
+    <Compile Include="Models\GetOrders\OrderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Rest\v2x\PagingModelTest.cs" />
     <Compile Include="Services\Rest\v2x\SearchCriteriaTest.cs" />

--- a/src/MagentoAccessTests/MagentoAccessTests.csproj
+++ b/src/MagentoAccessTests/MagentoAccessTests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Services\Soap\1_7_0_1_ce_1_9_0_1_ce\MagentoServiceLowLevelSoap_v_from_1_7_to_1_9_CE_Test.cs" />
     <Compile Include="Services\Soap\1_9_2_1_ce\MagentoServiceLowLevelSoap_v_1_9_2_1_ce_Test.cs" />
     <Compile Include="Services\Soap\2_0_2_0_ce\MagentoServiceLowLevelSoap_v_2_0_2_0_ce_Test.cs" />
+    <Compile Include="Models\GetOrders\Zoey_1_7_to_1_9_CE\ZoeyOrdersExtensionsTests.cs" />
     <Compile Include="TestEnvironment\MagentoServiceLowLevelSoapVFrom17To19CeThrowExcetpionStub.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MagentoAccessTests/Models/GetOrders/OrderTests.cs
+++ b/src/MagentoAccessTests/Models/GetOrders/OrderTests.cs
@@ -1,0 +1,95 @@
+﻿using FluentAssertions;
+using MagentoAccess.Models.GetOrders;
+using MagentoAccess.Models.Services.Soap.GetOrders;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using Order = MagentoAccess.Models.GetOrders.Order;
+
+namespace MagentoAccessTests.Models.GetOrders
+{
+	[ TestFixture ]
+	public class OrderTests
+	{
+		[ Test ]
+		public void OrderConstructor_ParameterOrderInfoResponse_GivenNullItems_ShouldReturnEmptyItems()
+		{
+			var orderInfoResponse = new OrderInfoResponse();
+
+			var result = new Order( orderInfoResponse );
+
+			result.Items.Should().BeEmpty();
+		}
+	}
+		
+	public class OrderExtensionsTests
+	{
+		[ Test ]
+		public void ToSvOrderItems_ParameterListOrderItemEntity_GivenNullItems_ShouldReturnEmptyItems()
+		{
+			List< OrderItemEntity > orderItems = null;
+
+			var result = orderItems.ToSvOrderItems().ToList();
+
+			result.Should().BeEmpty();
+		}
+
+		[ Test ]
+		public void ToSvOrderItems_ParameterListOrderItemEntity_ShouldReturnCorrectItems()
+		{
+			var orderItem = new OrderItemEntity
+			{
+				BaseDiscountAmount = "1.23",
+				BaseOriginalPrice = "2.34",
+				Sku = "testSku23",
+				Name = "Some product",
+				BaseTaxAmount = "0.40",
+				ItemId = "12345",
+				BasePrice = "22.33",
+				BaseRowTotal = "34.43",
+				DiscountAmount = "43.34",
+				OriginalPrice = "5.5",
+				Price = "2.22",
+				ProductType = "spoon",
+				QtyCanceled = "123",
+				QtyInvoiced = "3",
+				QtyOrdered = "1233",
+				QtyShipped = "7",
+				QtyRefunded = "1",
+				RowTotal = "2.34",
+				TaxAmount = "0.01",
+				TaxPercent = "6.01"
+			};
+			var orderItems = new List< OrderItemEntity >
+			{
+				orderItem,
+				new OrderItemEntity()
+			};
+
+			var result = orderItems.ToSvOrderItems().ToList();
+
+			result.Count.Should().Be( orderItems.Count );
+			var resultFirst = result.First();
+			resultFirst.BaseDiscountAmount.ToString().Should().Be( orderItem.BaseDiscountAmount );
+			resultFirst.BaseOriginalPrice.ToString().Should().Be( orderItem.BaseOriginalPrice );
+			resultFirst.Sku.Should().Be( orderItem.Sku );
+			resultFirst.Name.Should().Be( orderItem.Name );
+			resultFirst.BaseTaxAmount.ToString().Should().Be( orderItem.BaseTaxAmount );
+			resultFirst.ItemId.Should().Be( orderItem.ItemId );
+			resultFirst.BasePrice.ToString().Should().Be( orderItem.BasePrice );
+			resultFirst.BaseRowTotal.ToString().Should().Be( orderItem.BaseRowTotal );
+			resultFirst.DiscountAmount.ToString().Should().Be( orderItem.DiscountAmount );
+			resultFirst.OriginalPrice.ToString().Should().Be( orderItem.OriginalPrice );
+			resultFirst.Price.ToString().Should().Be( orderItem.Price );
+			resultFirst.ProductType.Should().Be( orderItem.ProductType );
+			resultFirst.QtyCanceled.ToString().Should().Be( orderItem.QtyCanceled );
+			resultFirst.QtyInvoiced.ToString().Should().Be( orderItem.QtyInvoiced );
+			resultFirst.QtyOrdered.ToString().Should().Be( orderItem.QtyOrdered );
+			resultFirst.QtyShipped.ToString().Should().Be( orderItem.QtyShipped );
+			resultFirst.QtyRefunded.ToString().Should().Be( orderItem.QtyRefunded );
+			resultFirst.RowTotal.ToString().Should().Be( orderItem.RowTotal );
+			resultFirst.TaxAmount.ToString().Should().Be( orderItem.TaxAmount );
+			resultFirst.TaxPercent.ToString().Should().Be( orderItem.TaxPercent );
+		}
+	}
+}

--- a/src/MagentoAccessTests/Models/GetOrders/Zoey_1_7_to_1_9_CE/ZoeyOrdersExtensionsTests.cs
+++ b/src/MagentoAccessTests/Models/GetOrders/Zoey_1_7_to_1_9_CE/ZoeyOrdersExtensionsTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using FluentAssertions;
+using MagentoAccess.Models.Services.Soap.GetOrders;
+using NUnit.Framework;
+using MagentoAccess.TsZoey_v_1_9_0_1_CE;
+
+namespace MagentoAccessTests.Models.GetOrders.Zoey_1_7_to_1_9_CE
+{
+	[ TestFixture ]
+	public class ZoeyOrdersExtensionsTests
+	{
+		[ Test ]
+		public void ToOrderItemEntities_ThenOrderItemCreated()
+		{
+			var orderInvoiceDiscount = "1.23";
+			var sku = "testSku1";
+			var qty = "3";
+			var price = "11.23";
+			var taxAmount = "2.34";
+			salesOrderInvoiceEntity[] orderInvoices = new []
+			{
+				new salesOrderInvoiceEntity
+				{
+					items = new []
+					{
+						new salesOrderInvoiceItemEntity 
+						{ 
+							sku = sku, 
+							qty = qty,
+							price = price,
+							tax_amount = taxAmount
+						}
+					},
+					discount_amount = orderInvoiceDiscount
+				},
+				new salesOrderInvoiceEntity
+				{
+					items = new [] { new salesOrderInvoiceItemEntity() }
+				}
+			};
+
+			var results = orderInvoices.ToOrderItemEntities();
+
+			results.Count().Should().Be( orderInvoices.Length );
+			var resultsFirst = results.First();
+			resultsFirst.Sku.Should().Be( sku );
+			resultsFirst.QtyOrdered.Should().Be( qty );
+			resultsFirst.Price.Should().Be( price );
+			resultsFirst.DiscountAmount.Should().Be( orderInvoiceDiscount );
+			resultsFirst.TaxAmount.Should().Be( taxAmount );
+		}
+
+		[ Test ]
+		public void ToOrderItemEntities_WhenOrderInvoicesIsNull_ThenReturnsEmpty()
+		{ 
+			salesOrderInvoiceEntity[] orderInvoices = null;
+
+			var results = orderInvoices.ToOrderItemEntities();
+
+			results.Should().BeEmpty();
+		}
+
+		[ Test ]
+		public void ToOrderItemEntities_WhenMultipleInvoicesItemsPerInvoice_ThenItemDiscountIsEmptyString()
+		{ 
+			salesOrderInvoiceEntity[] orderInvoices = new []
+			{
+				new salesOrderInvoiceEntity
+				{
+					items = new []
+					{
+						new salesOrderInvoiceItemEntity { sku = "testSku1" },
+						new salesOrderInvoiceItemEntity { sku = "testSku2" }
+					},
+					discount_amount = "1.23"
+				}
+			};
+
+			var results = orderInvoices.ToOrderItemEntities();
+
+			results.First().DiscountAmount.Should().BeEmpty();
+		}
+	}
+}


### PR DESCRIPTION
Zoey order items are no longer being returned in the "items" collection. Now they're in order_invoices.

Get order_invoices, order_shipments from the Zoey api for each order; map order_invoices to order items; added tests for new code
Handle order.Items = null; extracted the mapping of order items into a method and added tests; corrected a typo